### PR TITLE
command: add command to introspect the images

### DIFF
--- a/pkg/commands/images.go
+++ b/pkg/commands/images.go
@@ -1,0 +1,106 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ */
+
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/k8stopologyawareschedwg/deployer/pkg/images"
+)
+
+type imagesOptions struct {
+	jsonOutput bool
+	rawOutput  bool
+}
+
+func NewImagesCommand(commonOpts *CommonOptions) *cobra.Command {
+	opts := &imagesOptions{}
+	images := &cobra.Command{
+		Use:   "images",
+		Short: "dump the container images used to deploy",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			imo := newImageOutput()
+			if opts.rawOutput {
+				il := imo.ToList()
+				if opts.jsonOutput {
+					il.EncodeJSON(os.Stdout)
+				} else {
+					il.EncodeText(os.Stdout)
+				}
+			} else {
+				if opts.jsonOutput {
+					imo.EncodeJSON(os.Stdout)
+				} else {
+					imo.EncodeText(os.Stdout)
+				}
+			}
+			return nil
+		},
+		Args: cobra.NoArgs,
+	}
+	images.Flags().BoolVarP(&opts.jsonOutput, "json", "J", false, "output JSON, not text (default).")
+	images.Flags().BoolVarP(&opts.rawOutput, "raw", "r", false, "output raw list. Default is key=value object.")
+	return images
+}
+
+type imageOutput struct {
+	TopologyUpdater     string `json:"topology_updater"`
+	SchedulerPlugin     string `json:"scheduler_plugin"`
+	SchedulerController string `json:"scheduler_controller"`
+}
+
+func newImageOutput() imageOutput {
+	return imageOutput{
+		TopologyUpdater:     images.ResourceTopologyExporterDefaultImage,
+		SchedulerPlugin:     images.SchedulerPluginSchedulerDefaultImage,
+		SchedulerController: images.SchedulerPluginControllerDefaultImage,
+	}
+}
+
+type imageList []string
+
+func (imo imageOutput) ToList() imageList {
+	return []string{
+		imo.TopologyUpdater,
+		imo.SchedulerPlugin,
+		imo.SchedulerController,
+	}
+}
+
+func (il imageList) EncodeText(w io.Writer) {
+	fmt.Fprintf(w, "%s\n", strings.Join(il, "\n"))
+}
+
+func (il imageList) EncodeJSON(w io.Writer) {
+	json.NewEncoder(os.Stdout).Encode(il)
+}
+
+func (imo imageOutput) EncodeText(w io.Writer) {
+	fmt.Fprintf(w, "TAS_SCHEDULER_PLUGIN_IMAGE=%s\n", imo.SchedulerPlugin)
+	fmt.Fprintf(w, "TAS_SCHEDULER_PLUGIN_CONTROLLER_IMAGE=%s\n", imo.SchedulerController)
+	fmt.Fprintf(w, "TAS_RESOURCE_EXPORTER_IMAGE=%s\n", imo.TopologyUpdater)
+}
+
+func (imo imageOutput) EncodeJSON(w io.Writer) {
+	json.NewEncoder(w).Encode(imo)
+}

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -97,6 +97,7 @@ func NewRootCommand(extraCmds ...NewCommandFunc) *cobra.Command {
 		NewSetupCommand(commonOpts),
 		NewDetectCommand(commonOpts),
 		NewVersionCommand(commonOpts),
+		NewImagesCommand(commonOpts),
 	)
 	for _, extraCmd := range extraCmds {
 		root.AddCommand(extraCmd(commonOpts))

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -61,6 +61,12 @@ type detectionOutput struct {
 	Discovered   platform.Platform `json:"discovered"`
 }
 
+type imageOutput struct {
+	TopologyUpdater     string `json:"topology_updater"`
+	SchedulerPlugin     string `json:"scheduler_plugin"`
+	SchedulerController string `json:"scheduler_controller"`
+}
+
 func waitForReasource(body interface{}) {
 	gomega.Eventually(body)
 }

--- a/test/e2e/positive.go
+++ b/test/e2e/positive.go
@@ -70,6 +70,34 @@ var _ = ginkgo.Describe("[PositiveFlow] Deployer version", func() {
 	})
 })
 
+var _ = ginkgo.Describe("[PositiveFlow] Deployer images", func() {
+	ginkgo.Context("with the tool available", func() {
+		ginkgo.It("it should emit the images being used", func() {
+			cmdline := []string{
+				filepath.Join(binariesPath, "deployer"),
+				"images",
+				"--json",
+			}
+			fmt.Fprintf(ginkgo.GinkgoWriter, "running: %v\n", cmdline)
+
+			cmd := exec.Command(cmdline[0], cmdline[1:]...)
+			cmd.Stderr = ginkgo.GinkgoWriter
+
+			out, err := cmd.Output()
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			imo := imageOutput{}
+			if err := json.Unmarshal(out, &imo); err != nil {
+				ginkgo.Fail(fmt.Sprintf("Error unmarshalling output %q: %v", out, err))
+			}
+
+			gomega.Expect(imo.TopologyUpdater).ToNot(gomega.BeNil())
+			gomega.Expect(imo.SchedulerPlugin).ToNot(gomega.BeNil())
+			gomega.Expect(imo.SchedulerController).ToNot(gomega.BeNil())
+		})
+	})
+})
+
 var _ = ginkgo.Describe("[PositiveFlow] Deployer render", func() {
 	ginkgo.Context("with cluster image overrides", func() {
 		ginkgo.It("it should reflect the overrides in the output", func() {


### PR DESCRIPTION
This works as living documentation and makes
it trivial to find which images are going to
be used by the tool.

Signed-off-by: Francesco Romani <fromani@redhat.com>