### PR TITLE
rte: don't use floating tags

### DIFF
--- a/pkg/images/consts.go
+++ b/pkg/images/consts.go
@@ -19,5 +19,5 @@ package images
 const (
 	SchedulerPluginSchedulerDefaultImage  = "k8s.gcr.io/scheduler-plugins/kube-scheduler:v0.19.9"
 	SchedulerPluginControllerDefaultImage = "k8s.gcr.io/scheduler-plugins/controller:v0.19.9"
-	ResourceTopologyExporterDefaultImage  = "quay.io/openshift-kni/resource-topology-exporter:4.9-snapshot"
+	ResourceTopologyExporterDefaultImage  = "quay.io/openshift-kni/resource-topology-exporter:v0.0.19"
 )


### PR DESCRIPTION
Until we decide how to do mirroring and how to use sha256s,
let's at least use proper fixed tags and not floating tags
to identify the images we want to deploy.

Signed-off-by: Francesco Romani <fromani@redhat.com>