### PR TITLE
rte: bump to v0.0.20

### DIFF
--- a/pkg/images/consts.go
+++ b/pkg/images/consts.go
@@ -19,5 +19,5 @@ package images
 const (
 	SchedulerPluginSchedulerDefaultImage  = "k8s.gcr.io/scheduler-plugins/kube-scheduler:v0.19.9"
 	SchedulerPluginControllerDefaultImage = "k8s.gcr.io/scheduler-plugins/controller:v0.19.9"
-	ResourceTopologyExporterDefaultImage  = "quay.io/openshift-kni/resource-topology-exporter:v0.0.19"
+	ResourceTopologyExporterDefaultImage  = "quay.io/openshift-kni/resource-topology-exporter:v0.0.20"
 )


### PR DESCRIPTION
consume fixed image with shipped pciutils and pcidb.

Signed-off-by: Francesco Romani <fromani@redhat.com>