### PR TITLE
add gofmt to the build gh action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,8 +20,11 @@ jobs:
       with:
         go-version: 1.16
 
+    - name: format
+      run: ./hack/check-format.sh
+
     - name: build
       run: make all
 
-    - name: Test
+    - name: test
       run: make test-unit

--- a/hack/check-format.sh
+++ b/hack/check-format.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -eu
+
+DIFF=$( gofmt -s -d cmd pkg test )
+if [ -n "${DIFF}" ]; then
+	echo "${DIFF}"
+	exit 1
+fi
+exit 0

--- a/pkg/deployer/platform/detect/detect.go
+++ b/pkg/deployer/platform/detect/detect.go
@@ -19,8 +19,8 @@ package detect
 import (
 	"context"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/k8stopologyawareschedwg/deployer/pkg/clientutil"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"

--- a/pkg/manifests/api/api.go
+++ b/pkg/manifests/api/api.go
@@ -41,13 +41,13 @@ func (mf Manifests) ToObjects() []client.Object {
 
 func (mf Manifests) ToCreatableObjects(hp *deployer.Helper, log tlog.Logger) []deployer.WaitableObject {
 	return []deployer.WaitableObject{
-		deployer.WaitableObject{Obj: mf.Crd},
+		{Obj: mf.Crd},
 	}
 }
 
 func (mf Manifests) ToDeletableObjects(hp *deployer.Helper, log tlog.Logger) []deployer.WaitableObject {
 	return []deployer.WaitableObject{
-		deployer.WaitableObject{Obj: mf.Crd},
+		{Obj: mf.Crd},
 	}
 }
 

--- a/pkg/manifests/rte/rte.go
+++ b/pkg/manifests/rte/rte.go
@@ -126,20 +126,20 @@ func (mf Manifests) ToObjects() []client.Object {
 
 func (mf Manifests) ToCreatableObjects(hp *deployer.Helper, log tlog.Logger) []deployer.WaitableObject {
 	objs := []deployer.WaitableObject{
-		deployer.WaitableObject{Obj: mf.ClusterRole},
-		deployer.WaitableObject{Obj: mf.ClusterRoleBinding},
-		deployer.WaitableObject{
+		{Obj: mf.ClusterRole},
+		{Obj: mf.ClusterRoleBinding},
+		{
 			Obj:  mf.DaemonSet,
 			Wait: func() error { return wait.PodsToBeRunningByRegex(hp, log, mf.DaemonSet.Namespace, mf.DaemonSet.Name) },
 		},
 	}
 	if mf.ConfigMap != nil {
-		objs = append([]deployer.WaitableObject{deployer.WaitableObject{Obj: mf.ConfigMap}}, objs...)
+		objs = append([]deployer.WaitableObject{{Obj: mf.ConfigMap}}, objs...)
 	}
 	if mf.plat == platform.Kubernetes {
 		kubeObjs := []deployer.WaitableObject{
-			deployer.WaitableObject{Obj: mf.Namespace},
-			deployer.WaitableObject{Obj: mf.ServiceAccount},
+			{Obj: mf.Namespace},
+			{Obj: mf.ServiceAccount},
 		}
 		return append(kubeObjs, objs...)
 	}
@@ -149,23 +149,23 @@ func (mf Manifests) ToCreatableObjects(hp *deployer.Helper, log tlog.Logger) []d
 func (mf Manifests) ToDeletableObjects(hp *deployer.Helper, log tlog.Logger) []deployer.WaitableObject {
 	if mf.plat == platform.Kubernetes {
 		return []deployer.WaitableObject{
-			deployer.WaitableObject{
+			{
 				Obj:  mf.Namespace,
 				Wait: func() error { return wait.NamespaceToBeGone(hp, log, mf.Namespace.Name) },
 			},
 			// no need to remove objects created inside the namespace we just removed
-			deployer.WaitableObject{Obj: mf.ClusterRole},
-			deployer.WaitableObject{Obj: mf.ClusterRoleBinding},
-			deployer.WaitableObject{Obj: mf.ServiceAccount},
+			{Obj: mf.ClusterRole},
+			{Obj: mf.ClusterRoleBinding},
+			{Obj: mf.ServiceAccount},
 		}
 	}
 	objs := []deployer.WaitableObject{
-		deployer.WaitableObject{
+		{
 			Obj:  mf.DaemonSet,
 			Wait: func() error { return wait.PodsToBeGoneByRegex(hp, log, mf.DaemonSet.Namespace, mf.DaemonSet.Name) },
 		},
-		deployer.WaitableObject{Obj: mf.ClusterRole},
-		deployer.WaitableObject{Obj: mf.ClusterRoleBinding},
+		{Obj: mf.ClusterRole},
+		{Obj: mf.ClusterRoleBinding},
 	}
 	if mf.ConfigMap != nil {
 		objs = append(objs, deployer.WaitableObject{Obj: mf.ConfigMap})

--- a/pkg/manifests/sched/sched.go
+++ b/pkg/manifests/sched/sched.go
@@ -126,22 +126,22 @@ func (mf Manifests) ToObjects() []client.Object {
 
 func (mf Manifests) ToCreatableObjects(hp *deployer.Helper, log tlog.Logger) []deployer.WaitableObject {
 	return []deployer.WaitableObject{
-		deployer.WaitableObject{Obj: mf.Crd},
-		deployer.WaitableObject{Obj: mf.Namespace},
-		deployer.WaitableObject{Obj: mf.SAScheduler},
-		deployer.WaitableObject{Obj: mf.CRScheduler},
-		deployer.WaitableObject{Obj: mf.CRBScheduler},
-		deployer.WaitableObject{Obj: mf.ConfigMap},
-		deployer.WaitableObject{
+		{Obj: mf.Crd},
+		{Obj: mf.Namespace},
+		{Obj: mf.SAScheduler},
+		{Obj: mf.CRScheduler},
+		{Obj: mf.CRBScheduler},
+		{Obj: mf.ConfigMap},
+		{
 			Obj: mf.DPScheduler,
 			Wait: func() error {
 				return wait.PodsToBeRunningByRegex(hp, log, mf.DPScheduler.Namespace, mf.DPScheduler.Name)
 			},
 		},
-		deployer.WaitableObject{Obj: mf.SAController},
-		deployer.WaitableObject{Obj: mf.CRController},
-		deployer.WaitableObject{Obj: mf.CRBController},
-		deployer.WaitableObject{
+		{Obj: mf.SAController},
+		{Obj: mf.CRController},
+		{Obj: mf.CRBController},
+		{
 			Obj: mf.DPController,
 			Wait: func() error {
 				return wait.PodsToBeRunningByRegex(hp, log, mf.DPController.Namespace, mf.DPController.Name)
@@ -152,16 +152,16 @@ func (mf Manifests) ToCreatableObjects(hp *deployer.Helper, log tlog.Logger) []d
 
 func (mf Manifests) ToDeletableObjects(hp *deployer.Helper, log tlog.Logger) []deployer.WaitableObject {
 	return []deployer.WaitableObject{
-		deployer.WaitableObject{
+		{
 			Obj:  mf.Namespace,
 			Wait: func() error { return wait.NamespaceToBeGone(hp, log, mf.Namespace.Name) },
 		},
 		// no need to remove objects created inside the namespace we just removed
-		deployer.WaitableObject{Obj: mf.CRBScheduler},
-		deployer.WaitableObject{Obj: mf.CRScheduler},
-		deployer.WaitableObject{Obj: mf.CRBController},
-		deployer.WaitableObject{Obj: mf.CRController},
-		deployer.WaitableObject{Obj: mf.Crd},
+		{Obj: mf.CRBScheduler},
+		{Obj: mf.CRScheduler},
+		{Obj: mf.CRBController},
+		{Obj: mf.CRController},
+		{Obj: mf.Crd},
 	}
 }
 

--- a/test/e2e/utils/pods/pods.go
+++ b/test/e2e/utils/pods/pods.go
@@ -49,7 +49,7 @@ func GuaranteedSleeperPod(namespace, schedulerName string) *corev1.Pod {
 			SchedulerName: schedulerName,
 			RestartPolicy: corev1.RestartPolicyNever,
 			Containers: []corev1.Container{
-				corev1.Container{
+				{
 					Name:  "sleeper-gu-cnt",
 					Image: CentosImage,
 					// 1 hour (or >= 1h in general) is "forever" for our purposes

--- a/test/log/log.go
+++ b/test/log/log.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-type TestLogger struct{
+type TestLogger struct {
 	Logger io.Writer
 }
 


### PR DESCRIPTION
resync the tree to make it compliant with gofmt standard, and add an automated check to ensure we keep the codebase clean.