### PR TITLE
pkg: log: don't use the stdlib log pkg directly

### DIFF
--- a/pkg/commands/deploy.go
+++ b/pkg/commands/deploy.go
@@ -18,7 +18,6 @@ package commands
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/api"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
@@ -73,7 +72,7 @@ func NewRemoveCommand(commonOpts *CommonOptions) *cobra.Command {
 			})
 			if err != nil {
 				// intentionally keep going to remove as much as possible
-				log.Printf("error removing: %v", err)
+				la.Printf("error removing: %v", err)
 			}
 			err = rte.Remove(la, rte.Options{
 				Platform:         opts.clusterPlatform,
@@ -83,14 +82,14 @@ func NewRemoveCommand(commonOpts *CommonOptions) *cobra.Command {
 			})
 			if err != nil {
 				// intentionally keep going to remove as much as possible
-				log.Printf("error removing: %v", err)
+				la.Printf("error removing: %v", err)
 			}
 			err = api.Remove(la, api.Options{
 				Platform: opts.clusterPlatform,
 			})
 			if err != nil {
 				// intentionally keep going to remove as much as possible
-				log.Printf("error removing: %v", err)
+				la.Printf("error removing: %v", err)
 			}
 			return nil
 		},

--- a/pkg/deployer/deployer.go
+++ b/pkg/deployer/deployer.go
@@ -18,7 +18,6 @@ package deployer
 
 import (
 	"context"
-	"log"
 	"regexp"
 
 	corev1 "k8s.io/api/core/v1"
@@ -63,20 +62,20 @@ func NewHelper(tag string, log tlog.Logger) (*Helper, error) {
 func (hp *Helper) CreateObject(obj client.Object) error {
 	objKind := obj.GetObjectKind().GroupVersionKind().Kind // shortcut
 	if err := hp.cli.Create(context.TODO(), obj); err != nil {
-		log.Printf("-%5s> error creating %s %q: %v", hp.tag, objKind, obj.GetName(), err)
+		hp.log.Printf("-%5s> error creating %s %q: %v", hp.tag, objKind, obj.GetName(), err)
 		return err
 	}
-	log.Printf("-%5s> created %s %q", hp.tag, objKind, obj.GetName())
+	hp.log.Printf("-%5s> created %s %q", hp.tag, objKind, obj.GetName())
 	return nil
 }
 
 func (hp *Helper) DeleteObject(obj client.Object) error {
 	objKind := obj.GetObjectKind().GroupVersionKind().Kind // shortcut
 	if err := hp.cli.Delete(context.TODO(), obj); err != nil {
-		log.Printf("-%5s> error deleting %s %q: %v", hp.tag, objKind, obj.GetName(), err)
+		hp.log.Printf("-%5s> error deleting %s %q: %v", hp.tag, objKind, obj.GetName(), err)
 		return err
 	}
-	log.Printf("-%5s> deleted %s %q", hp.tag, objKind, obj.GetName())
+	hp.log.Printf("-%5s> deleted %s %q", hp.tag, objKind, obj.GetName())
 	return nil
 }
 


### PR DESCRIPTION
It's fine for the project to use the interfaces defined
in the stdlib log package (we WANT to keep doing that)
but we should not log directly using the functions
in that package.

Signed-off-by: Francesco Romani <fromani@redhat.com>