### PR TITLE
rte: use role, not clusterrole

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -94,6 +94,46 @@ func ServiceAccount(component, subComponent string) (*corev1.ServiceAccount, err
 	return sa, nil
 }
 
+func Role(component, subComponent string) (*rbacv1.Role, error) {
+	if err := validateComponent(component); err != nil {
+		return nil, err
+	}
+	if err := validateSubComponent(component, subComponent); err != nil {
+		return nil, err
+	}
+
+	obj, err := loadObject(filepath.Join("yaml", component, subComponent, "role.yaml"))
+	if err != nil {
+		return nil, err
+	}
+
+	role, ok := obj.(*rbacv1.Role)
+	if !ok {
+		return nil, fmt.Errorf("unexpected type, got %t", obj)
+	}
+	return role, nil
+}
+
+func RoleBinding(component, subComponent string) (*rbacv1.RoleBinding, error) {
+	if err := validateComponent(component); err != nil {
+		return nil, err
+	}
+	if err := validateSubComponent(component, subComponent); err != nil {
+		return nil, err
+	}
+
+	obj, err := loadObject(filepath.Join("yaml", component, subComponent, "rolebinding.yaml"))
+	if err != nil {
+		return nil, err
+	}
+
+	rb, ok := obj.(*rbacv1.RoleBinding)
+	if !ok {
+		return nil, fmt.Errorf("unexpected type, got %t", obj)
+	}
+	return rb, nil
+}
+
 func ClusterRole(component, subComponent string) (*rbacv1.ClusterRole, error) {
 	if err := validateComponent(component); err != nil {
 		return nil, err

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -101,6 +101,102 @@ func TestGetServiceAccount(t *testing.T) {
 	}
 }
 
+func TestGetRole(t *testing.T) {
+	type testCase struct {
+		component    string
+		subComponent string
+		expectError  bool
+	}
+
+	testCases := []testCase{
+		{
+			component:   "unknown-wrong",
+			expectError: true,
+		},
+		{
+			component:   ComponentAPI,
+			expectError: true,
+		},
+		{
+			component:    ComponentSchedulerPlugin,
+			subComponent: SubComponentSchedulerPluginScheduler,
+			expectError:  true,
+		},
+		{
+			component:    ComponentSchedulerPlugin,
+			subComponent: SubComponentSchedulerPluginController,
+			expectError:  true,
+		},
+		{
+			component:   ComponentResourceTopologyExporter,
+			expectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.component, func(t *testing.T) {
+			obj, err := Role(tc.component, tc.subComponent)
+			if tc.expectError {
+				if err == nil || obj != nil {
+					t.Fatalf("nil err or non-nil obj=%v", obj)
+				}
+			} else {
+				if err != nil || obj == nil {
+					t.Fatalf("nil obj or non-nil err=%v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestGetRoleBinding(t *testing.T) {
+	type testCase struct {
+		component    string
+		subComponent string
+		expectError  bool
+	}
+
+	testCases := []testCase{
+		{
+			component:   "unknown-wrong",
+			expectError: true,
+		},
+		{
+			component:   ComponentAPI,
+			expectError: true,
+		},
+		{
+			component:    ComponentSchedulerPlugin,
+			subComponent: SubComponentSchedulerPluginScheduler,
+			expectError:  true,
+		},
+		{
+			component:    ComponentSchedulerPlugin,
+			subComponent: SubComponentSchedulerPluginController,
+			expectError:  true,
+		},
+		{
+			component:   ComponentResourceTopologyExporter,
+			expectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.component, func(t *testing.T) {
+			obj, err := RoleBinding(tc.component, tc.subComponent)
+			if tc.expectError {
+				if err == nil || obj != nil {
+					t.Fatalf("nil err or non-nil obj=%v", obj)
+				}
+			} else {
+				if err != nil || obj == nil {
+					t.Fatalf("nil obj or non-nil err=%v", err)
+				}
+			}
+		})
+	}
+}
+
 func TestGetClusterRole(t *testing.T) {
 	type testCase struct {
 		component    string
@@ -129,7 +225,7 @@ func TestGetClusterRole(t *testing.T) {
 		},
 		{
 			component:   ComponentResourceTopologyExporter,
-			expectError: false,
+			expectError: true,
 		},
 	}
 
@@ -177,7 +273,7 @@ func TestGetClusterRoleBinding(t *testing.T) {
 		},
 		{
 			component:   ComponentResourceTopologyExporter,
-			expectError: false,
+			expectError: true,
 		},
 	}
 

--- a/pkg/manifests/yaml/rte/role.yaml
+++ b/pkg/manifests/yaml/rte/role.yaml
@@ -1,7 +1,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: rte
+  namespace: default
 rules:
 - apiGroups: ["topology.node.k8s.io"]
   resources: ["noderesourcetopologies"]

--- a/pkg/manifests/yaml/rte/rolebinding.yaml
+++ b/pkg/manifests/yaml/rte/rolebinding.yaml
@@ -1,13 +1,14 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: rte
+  namespace: default
 subjects:
 - kind: ServiceAccount
   name: rte
   namespace: default
 roleRef:
-  kind: ClusterRole
+  kind: Role
   name: rte
   apiGroup: rbac.authorization.k8s.io
 


### PR DESCRIPTION
There is no strong reason to use a clusterrole{,binding} for RTE,
while using role{,binding} would make the resources used by RTE
almost entirely confined in a NS, thus easier to track and to remove.

No intended change in behaviour.

Signed-off-by: Francesco Romani <fromani@redhat.com>