### PR TITLE
rte: support to deploy on existing namespace

### DIFF
--- a/pkg/deployer/api/api.go
+++ b/pkg/deployer/api/api.go
@@ -17,6 +17,10 @@
 package api
 
 import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
 	apimanifests "github.com/k8stopologyawareschedwg/deployer/pkg/manifests/api"
@@ -25,6 +29,10 @@ import (
 
 type Options struct {
 	Platform platform.Platform
+}
+
+func SetupNamespace(plat platform.Platform) (*corev1.Namespace, string, error) {
+	return nil, "", fmt.Errorf("the API is a cluster scoped resource")
 }
 
 func Deploy(log tlog.Logger, opts Options) error {

--- a/pkg/deployer/deployer.go
+++ b/pkg/deployer/deployer.go
@@ -122,8 +122,8 @@ func (hp *Helper) IsDaemonSetRunning(namespace, name string) (bool, error) {
 		}
 		return false, err
 	}
-	hp.log.Printf("daemonset %q %q running count %d desired %d", namespace, name, ds.Status.CurrentNumberScheduled, ds.Status.DesiredNumberScheduled)
-	return (ds.Status.DesiredNumberScheduled == ds.Status.CurrentNumberScheduled), nil
+	hp.log.Printf("daemonset %q %q desired %d scheduled %d ready %d", namespace, name, ds.Status.DesiredNumberScheduled, ds.Status.CurrentNumberScheduled, ds.Status.NumberReady)
+	return (ds.Status.DesiredNumberScheduled > 0 && ds.Status.DesiredNumberScheduled == ds.Status.NumberReady), nil
 }
 
 func (hp *Helper) IsDaemonSetGone(namespace, name string) (bool, error) {

--- a/pkg/deployer/sched/sched.go
+++ b/pkg/deployer/sched/sched.go
@@ -19,6 +19,8 @@ package sched
 import (
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
 	rtemanifests "github.com/k8stopologyawareschedwg/deployer/pkg/manifests/rte"
@@ -32,6 +34,10 @@ type Options struct {
 	Replicas         int32
 	RTEConfigData    string
 	PullIfNotPresent bool
+}
+
+func SetupNamespace(plat platform.Platform) (*corev1.Namespace, string, error) {
+	return nil, "", fmt.Errorf("not yet implemented")
 }
 
 func Deploy(log tlog.Logger, opts Options) error {

--- a/pkg/deployer/wait/wait.go
+++ b/pkg/deployer/wait/wait.go
@@ -86,3 +86,17 @@ func NamespaceToBeGone(hp *deployer.Helper, log tlog.Logger, namespace string) e
 		return true, nil
 	})
 }
+
+func DaemonSetToBeRunning(hp *deployer.Helper, log tlog.Logger, namespace, name string) error {
+	log.Printf("wait for the daemonset %q %q to be running", namespace, name)
+	return wait.PollImmediate(3*time.Second, 3*time.Minute, func() (bool, error) {
+		return hp.IsDaemonSetRunning(namespace, name)
+	})
+}
+
+func DaemonSetToBeGone(hp *deployer.Helper, log tlog.Logger, namespace, name string) error {
+	log.Printf("wait for the daemonset %q %q to be gone", namespace, name)
+	return wait.PollImmediate(3*time.Second, 3*time.Minute, func() (bool, error) {
+		return hp.IsDaemonSetGone(namespace, name)
+	})
+}

--- a/pkg/manifests/sched/sched.go
+++ b/pkg/manifests/sched/sched.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	namespaceOCP = "openshift-topology-aware-scheduler"
+	NamespaceOpenShift = "openshift-topology-aware-scheduler"
 )
 
 type Manifests struct {
@@ -90,7 +90,7 @@ func (mf Manifests) Update(logger tlog.Logger, options UpdateOptions) Manifests 
 	manifests.UpdateSchedulerPluginSchedulerDeployment(ret.DPScheduler, options.PullIfNotPresent)
 	manifests.UpdateSchedulerPluginControllerDeployment(ret.DPController, options.PullIfNotPresent)
 	if mf.plat == platform.OpenShift {
-		ret.Namespace.Name = namespaceOCP
+		ret.Namespace.Name = NamespaceOpenShift
 	}
 
 	ret.SAController.Namespace = ret.Namespace.Name


### PR DESCRIPTION
Make the namespace setup explicit in the deployment steps. We intentionally keep a consistent API for now, even for modules on which setup namespace doesn't make sense, because the component is (and will always be) cluster-scoped (API) or because we need separate namespaces in any case (scheduler).

The main benefit of this change is that we perform a quite deep cleanup and streamlining in the RTE flow, and we handle in a bit friedlier its API.

In general, in the kubernetes flow we should always setup a separate namespace, but there are noteworthy cases (operators) on which the namespace setup should be handled on a different explicit step, and with this PR we can now handle those cases in a simpler way.