### PR TITLE
manifests: object state reporting

### DIFF
--- a/pkg/clientutil/client.go
+++ b/pkg/clientutil/client.go
@@ -42,8 +42,8 @@ func New() (client.Client, error) {
 		return nil, err
 	}
 
-	c, err := client.New(cfg, client.Options{})
-	return c, err
+	cli, err := client.New(cfg, client.Options{})
+	return cli, err
 }
 
 // NewK8s returns a kubernetes clientset

--- a/pkg/deployer/deployer.go
+++ b/pkg/deployer/deployer.go
@@ -46,11 +46,15 @@ func NewHelper(tag string, log tlog.Logger) (*Helper, error) {
 	if err != nil {
 		return nil, err
 	}
+	return NewHelperWithClient(cli, tag, log), nil
+}
+
+func NewHelperWithClient(cli client.Client, tag string, log tlog.Logger) *Helper {
 	return &Helper{
 		tag: tag,
 		cli: cli,
 		log: log,
-	}, nil
+	}
 }
 
 func (hp *Helper) CreateObject(obj client.Object) error {

--- a/pkg/manifests/api/api.go
+++ b/pkg/manifests/api/api.go
@@ -17,6 +17,8 @@
 package api
 
 import (
+	"context"
+
 	apiextensionv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -77,4 +79,22 @@ func GetManifests(plat platform.Platform) (Manifests, error) {
 	}
 
 	return mf, nil
+}
+
+type ExistingManifests struct {
+	Existing Manifests
+	CrdError error
+}
+
+func (mf Manifests) FromClient(ctx context.Context, cli client.Client) ExistingManifests {
+	ret := ExistingManifests{
+		Existing: Manifests{
+			plat: mf.plat,
+		},
+	}
+	crd := apiextensionv1.CustomResourceDefinition{}
+	if ret.CrdError = cli.Get(ctx, client.ObjectKeyFromObject(mf.Crd), &crd); ret.CrdError == nil {
+		ret.Existing.Crd = &crd
+	}
+	return ret
 }

--- a/pkg/manifests/api/api.go
+++ b/pkg/manifests/api/api.go
@@ -26,6 +26,8 @@ import (
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/manifests"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/manifests/compare"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/manifests/merge"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/tlog"
 )
 
@@ -84,6 +86,18 @@ func GetManifests(plat platform.Platform) (Manifests, error) {
 type ExistingManifests struct {
 	Existing Manifests
 	CrdError error
+}
+
+func (em ExistingManifests) State(mf Manifests) []manifests.ObjectState {
+	return []manifests.ObjectState{
+		{
+			Existing: em.Existing.Crd,
+			Error:    em.CrdError,
+			Desired:  mf.Crd.DeepCopy(),
+			Compare:  compare.Object,
+			Merge:    merge.MetadataForUpdate,
+		},
+	}
 }
 
 func (mf Manifests) FromClient(ctx context.Context, cli client.Client) ExistingManifests {

--- a/pkg/manifests/compare/compare.go
+++ b/pkg/manifests/compare/compare.go
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ */
+
+package compare
+
+import (
+	"k8s.io/apimachinery/pkg/api/equality"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func Object(existing, obj client.Object) (bool, error) {
+	return equality.Semantic.DeepEqual(existing, obj), nil
+}

--- a/pkg/manifests/compare/compare_test.go
+++ b/pkg/manifests/compare/compare_test.go
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ */
+
+package compare
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type testCase struct {
+	description   string
+	objA          client.Object
+	objB          client.Object
+	expectedEqual bool
+	expectedError error
+}
+
+func TestCompareObject(t *testing.T) {
+	testCases := []testCase{
+		{
+			description:   "both nil",
+			expectedEqual: true,
+		},
+		{
+			description:   "nil vs non-nil",
+			objB:          &corev1.Namespace{},
+			expectedEqual: false,
+		},
+		{
+			description:   "non-nil vs nil",
+			objA:          &corev1.Namespace{},
+			expectedEqual: false,
+		},
+		{
+			description: "init vs init",
+			objA: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "compare-test",
+				},
+			},
+			objB: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "compare-test",
+				},
+			},
+			expectedEqual: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			res, err := Object(tc.objA, tc.objB)
+			if res != tc.expectedEqual {
+				t.Errorf("expected equal=%t actual=%t", tc.expectedEqual, res)
+			}
+			if err != tc.expectedError {
+				t.Errorf("expected err=%v actual=%v", tc.expectedError, err)
+			}
+		})
+	}
+}

--- a/pkg/manifests/merge/merge.go
+++ b/pkg/manifests/merge/merge.go
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ */
+
+package merge
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	ErrWrongObjectType    = fmt.Errorf("given object does not match the merger")
+	ErrMismatchingObjects = fmt.Errorf("given objects have mismatching types")
+)
+
+func ServiceAccountForUpdate(current, updated client.Object) (client.Object, error) {
+	curSA, ok := current.(*corev1.ServiceAccount)
+	if !ok {
+		return updated, ErrWrongObjectType
+	}
+	updSA, ok := updated.(*corev1.ServiceAccount)
+	if !ok {
+		return updated, ErrMismatchingObjects
+	}
+	updSA.Secrets = curSA.Secrets
+	return MetadataForUpdate(current, updated)
+}
+
+func ObjectForUpdate(current, updated client.Object) (client.Object, error) {
+	return MetadataForUpdate(current, updated)
+}
+
+func MetadataForUpdate(current, updated client.Object) (client.Object, error) {
+	updated.SetCreationTimestamp(current.GetCreationTimestamp())
+	updated.SetSelfLink(current.GetSelfLink())
+	updated.SetGeneration(current.GetGeneration())
+	updated.SetUID(current.GetUID())
+	updated.SetResourceVersion(current.GetResourceVersion())
+	updated.SetManagedFields(current.GetManagedFields())
+	updated.SetFinalizers(current.GetFinalizers())
+
+	Annotations(current, updated)
+	Labels(current, updated)
+
+	return updated, nil
+}
+
+func Annotations(current, updated client.Object) (client.Object, error) {
+	updatedAnnotations := updated.GetAnnotations()
+	curAnnotations := current.GetAnnotations()
+
+	if curAnnotations == nil {
+		curAnnotations = map[string]string{}
+	}
+
+	for k, v := range updatedAnnotations {
+		curAnnotations[k] = v
+	}
+
+	if len(curAnnotations) != 0 {
+		updated.SetAnnotations(curAnnotations)
+	}
+	return updated, nil
+}
+
+func Labels(current, updated client.Object) (client.Object, error) {
+	updatedLabels := updated.GetLabels()
+	curLabels := current.GetLabels()
+
+	if curLabels == nil {
+		curLabels = map[string]string{}
+	}
+
+	for k, v := range updatedLabels {
+		curLabels[k] = v
+	}
+
+	if len(curLabels) != 0 {
+		updated.SetLabels(curLabels)
+	}
+	return updated, nil
+}

--- a/pkg/manifests/sched/sched.go
+++ b/pkg/manifests/sched/sched.go
@@ -17,6 +17,8 @@
 package sched
 
 import (
+	"context"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -218,6 +220,15 @@ func GetManifests(plat platform.Platform) (Manifests, error) {
 	}
 
 	return mf, nil
+}
+
+type ExistingManifests struct {
+	Existing Manifests
+}
+
+func (mf Manifests) FromClient(ctx context.Context, cli client.Client) ExistingManifests {
+	// TODO
+	return ExistingManifests{}
 }
 
 func newInt32(value int32) *int32 {

--- a/pkg/manifests/sched/sched.go
+++ b/pkg/manifests/sched/sched.go
@@ -226,6 +226,10 @@ type ExistingManifests struct {
 	Existing Manifests
 }
 
+func (em ExistingManifests) State(mf Manifests) []manifests.ObjectState {
+	return nil
+}
+
 func (mf Manifests) FromClient(ctx context.Context, cli client.Client) ExistingManifests {
 	// TODO
 	return ExistingManifests{}


### PR DESCRIPTION
We aim to provide the foundations needed to support a reconcile loop using the `pkg/manifests` code.

ObjectState is a umbrella term to implement manifest updates. We add facilities to extract the manifest state and to provide
foundations ofr a reconcile loop. 

The code will provide
- status of the current system: existing manifests (+ error in fetching   them, if any)
- status of the desired state of the system
- helper functions to compare manifests (existing vs desired)
- helper functions to merge manifests, which will be used in the
  reconciliation loops.
