### PR TITLE
Manifests.Update() will be called on fresh DaemonSet copy

### DIFF
--- a/pkg/manifests/rte/rte_test.go
+++ b/pkg/manifests/rte/rte_test.go
@@ -1,0 +1,74 @@
+package rte
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
+)
+
+func TestMultipleUpdateWithDifferentNamespaceOptions(t *testing.T) {
+	type testCase struct {
+		name       string
+		mf         Manifests
+		options    []UpdateOptions
+		expectedNs string
+	}
+
+	mfK8s, _ := GetManifests(platform.Kubernetes)
+	mfOcp, _ := GetManifests(platform.OpenShift)
+	testCases := []testCase{
+		{
+			name: "kubernetes manifests",
+			mf:   mfK8s,
+			options: []UpdateOptions{
+				{
+					Namespace: "one",
+				},
+				{
+					Namespace: "two",
+				},
+			},
+			expectedNs: "two",
+		},
+		{
+			name: "openshift manifests",
+			mf:   mfOcp,
+			options: []UpdateOptions{
+				{
+					Namespace: "two",
+				},
+				{
+					Namespace: "one",
+				},
+			},
+			expectedNs: "one",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// with an UpdateOptions slice in size of N,
+			// the mf should be updated with options that appears at the Nth index.
+			for _, opt := range tc.options {
+				tc.mf = tc.mf.Update(opt)
+			}
+			if tc.mf.DaemonSet.Namespace != tc.expectedNs {
+				t.Errorf("testcase %q expected namespace %q got namespace %q", tc.name, tc.expectedNs, tc.mf.DaemonSet.Namespace)
+			}
+			ns := getExportedNamespace(tc.mf.DaemonSet.Spec.Template.Spec.Containers[0].Command)
+			if ns != tc.expectedNs {
+				t.Errorf("testcase %q expected namespace %q got namespace %q", tc.name, tc.expectedNs, ns)
+			}
+		})
+	}
+}
+
+func getExportedNamespace(cmd []string) string {
+	for _, s := range cmd {
+		if strings.Contains(s, "--export-namespace=") {
+			return strings.TrimPrefix(s, "--export-namespace=")
+		}
+	}
+	return ""
+}

--- a/pkg/manifests/updates.go
+++ b/pkg/manifests/updates.go
@@ -1,12 +1,11 @@
 package manifests
 
 import (
+	"github.com/drone/envsubst"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-
-	"github.com/drone/envsubst"
 
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/images"

--- a/pkg/manifests/updates_test.go
+++ b/pkg/manifests/updates_test.go
@@ -45,6 +45,16 @@ func TestUpdateResourceTopologyExporterCommandMultipleCalls(t *testing.T) {
 			plat:     platform.OpenShift,
 			expected: []string{"/bin/ocpfoo", "-v=3", "--baz=42", "--topology-manager-policy=single-numa-node"},
 		},
+		{
+			name: "kubernetes, with vars",
+			args: []string{"/bin/k8sfoo", "FOO=${PLACEHOLDER1}", "BAR=${PLACEHOLDER2}"},
+			vars: map[string]string{
+				"PLACEHOLDER1": "VALUE1",
+				"PLACEHOLDER2": "VALUE2",
+			},
+			plat:     platform.Kubernetes,
+			expected: []string{"/bin/k8sfoo", "FOO=VALUE1", "BAR=VALUE2", "--kubelet-config-file=/host-var/lib/kubelet/config.yaml"},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
The deployer's buisness logic was intended to get executed once per the deployer process's lifetime.
We reused the same logic on the numaresources-operator, but on the operator we're performing multiple updates on the same manifests instance - IOW the Update() function processed a dirty copy of DaemonSet object if more than a single Update() call being executed.

This lead to several bugs:
1. https://github.com/k8stopologyawareschedwg/deployer/pull/55
2. The export-namespace https://github.com/k8stopologyawareschedwg/deployer/blob/main/pkg/manifests/yaml/rte/daemonset.yaml#L20 command argument, not updated properly (the initial reason for PR)

In order to solve this issue we change the Update() logic to always work on a fresh copy of DaemonSet object, hence we won't carry former changes during the Update() call.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>