### PR TITLE
Add missing logic for updating metrics port

### DIFF
--- a/pkg/manifests/yaml/rte/daemonset.yaml
+++ b/pkg/manifests/yaml/rte/daemonset.yaml
@@ -37,6 +37,8 @@ spec:
               fieldPath: metadata.name
         - name: REFERENCE_CONTAINER_NAME
           value: shared-pool-container
+        - name: METRICS_PORT
+          value: "${METRICS_PORT}"
         volumeMounts:
           - name: host-sys
             mountPath: "/host-sys"


### PR DESCRIPTION
The deployer is not updating the DaemonSet with the necessary configuration for support metrics exports
as we have in the RTE repo: https://github.com/k8stopologyawareschedwg/resource-topology-exporter/blob/master/manifests/resource-topology-exporter-ds.yaml#L42

Signed-off-by: Talor Itzhak <titzhak@redhat.com>