### PR TITLE
sched: clusterrole: add missing permissions

### DIFF
--- a/pkg/manifests/yaml/sched/scheduler/clusterrole.yaml
+++ b/pkg/manifests/yaml/sched/scheduler/clusterrole.yaml
@@ -54,7 +54,7 @@ rules:
   resources: ["subjectaccessreviews"]
   verbs: ["create"]
 - apiGroups: ["storage.k8s.io"]
-  resources: ["csinodes", "storageclasses"]
+  resources: ["csinodes", "storageclasses", "csidrivers", "csistoragecapacities"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["scheduling.sigs.k8s.io"]
   resources: ["podgroups", "elasticquotas"]


### PR DESCRIPTION
Add missing (intentionally RO) permissions to storage.k8s.io resources.
Looks like the core scheduler needs to watch these resources, and if it fails to watch them the scheduler doesn't initializes itself
correctly.

TL;DR: with the extra permissions, the scheduling works as expected;
without, it doesn't: pod requesting the secondary scheduler keep being Pending, even though NRT objects are populated correctly.

Signed-off-by: Francesco Romani <fromani@redhat.com>