### PR TITLE
Expose config map functions

### DIFF
--- a/pkg/manifests/rte/rte.go
+++ b/pkg/manifests/rte/rte.go
@@ -32,6 +32,10 @@ import (
 	"github.com/k8stopologyawareschedwg/deployer/pkg/tlog"
 )
 
+const (
+	configDataField = "config.yaml"
+)
+
 type Manifests struct {
 	ServiceAccount     *corev1.ServiceAccount
 	Role               *rbacv1.Role
@@ -120,12 +124,12 @@ func (mf Manifests) Update(options UpdateOptions) Manifests {
 	}
 
 	if len(options.ConfigData) > 0 {
-		ret.ConfigMap = createConfigMap(ret.DaemonSet.Name, ret.DaemonSet.Namespace, options.ConfigData)
+		ret.ConfigMap = CreateConfigMap(ret.DaemonSet.Namespace, ret.DaemonSet.Name, options.ConfigData)
 	}
 	return ret
 }
 
-func createConfigMap(name string, namespace string, configData string) *corev1.ConfigMap {
+func CreateConfigMap(namespace, name, configData string) *corev1.ConfigMap {
 	cm := &corev1.ConfigMap{
 		// TODO: why is this needed?
 		TypeMeta: metav1.TypeMeta{
@@ -137,7 +141,7 @@ func createConfigMap(name string, namespace string, configData string) *corev1.C
 			Namespace: namespace,
 		},
 		Data: map[string]string{
-			"config.yaml": configData,
+			configDataField: configData,
 		},
 	}
 	return cm

--- a/pkg/manifests/rte/rte.go
+++ b/pkg/manifests/rte/rte.go
@@ -111,12 +111,13 @@ func (mf Manifests) Update(options UpdateOptions) Manifests {
 	manifests.UpdateClusterRoleBinding(ret.ClusterRoleBinding, mf.ServiceAccount.Name, mf.ServiceAccount.Namespace)
 
 	ret.DaemonSet.Spec.Template.Spec.ServiceAccountName = mf.ServiceAccount.Name
+
+	rteConfigMapName := ""
+	if ret.ConfigMap != nil {
+		rteConfigMapName = manifests.RTEConfigMapName
+	}
 	manifests.UpdateResourceTopologyExporterDaemonSet(
-		ret.DaemonSet,
-		ret.ConfigMap,
-		options.PullIfNotPresent,
-		options.NodeSelector,
-	)
+		ret.DaemonSet, rteConfigMapName, options.PullIfNotPresent, options.NodeSelector)
 
 	if mf.plat == platform.OpenShift {
 		manifests.UpdateMachineConfig(ret.MachineConfig, options.Name, options.MachineConfigPoolSelector)

--- a/pkg/manifests/updates_test.go
+++ b/pkg/manifests/updates_test.go
@@ -87,3 +87,55 @@ func TestUpdateMetricsPort(t *testing.T) {
 		})
 	}
 }
+
+func TestAddConfigMapToDaemonSet(t *testing.T) {
+	ds := appsv1.DaemonSet{
+		Spec: appsv1.DaemonSetSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{},
+					},
+				},
+			},
+		},
+	}
+	if len(ds.Spec.Template.Spec.Containers[0].VolumeMounts) != 0 {
+		t.Errorf("unexpected volume mount")
+	}
+	if len(ds.Spec.Template.Spec.Volumes) != 0 {
+		t.Errorf("unexpected volume declaration")
+	}
+
+	UpdateResourceTopologyExporterContainerConfig(&ds.Spec.Template.Spec, &ds.Spec.Template.Spec.Containers[0], "test-cfg")
+	if len(ds.Spec.Template.Spec.Containers[0].VolumeMounts) != 1 {
+		t.Errorf("missing volume mount")
+	}
+	if len(ds.Spec.Template.Spec.Volumes) != 1 {
+		t.Errorf("missing volume declaration")
+	}
+}
+
+func TestAddConfigMapToPod(t *testing.T) {
+	pod := &v1.Pod{
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{},
+			},
+		},
+	}
+	if len(pod.Spec.Containers[0].VolumeMounts) != 0 {
+		t.Errorf("unexpected volume mount")
+	}
+	if len(pod.Spec.Volumes) != 0 {
+		t.Errorf("unexpected volume declaration")
+	}
+
+	UpdateResourceTopologyExporterContainerConfig(&pod.Spec, &pod.Spec.Containers[0], "test-cfg")
+	if len(pod.Spec.Containers[0].VolumeMounts) != 1 {
+		t.Errorf("missing volume mount")
+	}
+	if len(pod.Spec.Volumes) != 1 {
+		t.Errorf("missing volume declaration")
+	}
+}


### PR DESCRIPTION
Expose functions to create and inject the RTE config map, to make it easier for external project to consume the deployer codebase.