### PR TITLE
Mount configmap with the correct name

### DIFF
--- a/pkg/manifests/rte/rte.go
+++ b/pkg/manifests/rte/rte.go
@@ -113,8 +113,12 @@ func (mf Manifests) Update(options UpdateOptions) Manifests {
 	ret.DaemonSet.Spec.Template.Spec.ServiceAccountName = mf.ServiceAccount.Name
 
 	rteConfigMapName := ""
+	if len(options.ConfigData) > 0 {
+		ret.ConfigMap = CreateConfigMap(ret.DaemonSet.Namespace, manifests.RTEConfigMapName, options.ConfigData)
+	}
+
 	if ret.ConfigMap != nil {
-		rteConfigMapName = manifests.RTEConfigMapName
+		rteConfigMapName = ret.ConfigMap.Name
 	}
 	manifests.UpdateResourceTopologyExporterDaemonSet(
 		ret.DaemonSet, rteConfigMapName, options.PullIfNotPresent, options.NodeSelector)
@@ -124,9 +128,6 @@ func (mf Manifests) Update(options UpdateOptions) Manifests {
 		manifests.UpdateSecurityContextConstraint(ret.SecurityContextConstraint, ret.ServiceAccount)
 	}
 
-	if len(options.ConfigData) > 0 {
-		ret.ConfigMap = CreateConfigMap(ret.DaemonSet.Namespace, ret.DaemonSet.Name, options.ConfigData)
-	}
 	return ret
 }
 

--- a/pkg/manifests/updates.go
+++ b/pkg/manifests/updates.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	metricsPort        = 2112
-	rteConfigMountName = "rte-config"
+	rteConfigMountName = "rte-config-volume"
 	RTEConfigMapName   = "rte-config"
 )
 


### PR DESCRIPTION
We're creating the ConfigMap object with a name which is based on the DaemonSet's name,
but when we're mounting the ConfigMap as a volume we're using a constant name which is not the real ConfigMap's name.

The result is that the pod is getting deployed without a mounted ConfigMap.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>