### PR TITLE
Delete scheduler rolebinding resource

### DIFF
--- a/pkg/manifests/sched/sched.go
+++ b/pkg/manifests/sched/sched.go
@@ -165,6 +165,7 @@ func (mf Manifests) ToDeletableObjects(hp *deployer.Helper, log tlog.Logger) []d
 		// no need to remove objects created inside the namespace we just removed
 		{Obj: mf.CRBScheduler},
 		{Obj: mf.CRScheduler},
+		{Obj: mf.RBScheduler},
 		{Obj: mf.CRBController},
 		{Obj: mf.CRController},
 		{Obj: mf.RBController},


### PR DESCRIPTION
The rolebinding deployed at the kube-system ns and not in the scheduler ns, thus we need to delete it explicitly

Signed-off-by: Talor Itzhak <titzhak@redhat.com>