### PR TITLE
Add podreadiness under daemonset

### DIFF
--- a/pkg/manifests/yaml/rte/daemonset.yaml
+++ b/pkg/manifests/yaml/rte/daemonset.yaml
@@ -11,6 +11,9 @@ spec:
       labels:
         name: resource-topology
     spec:
+      readinessGates:
+      - conditionType: "PodresourcesFetched"
+      - conditionType: "NodeTopologyUpdated"
       serviceAccountName: rte
       containers:
       - name: resource-topology-exporter


### PR DESCRIPTION
This patch will allow RTE to use the podreadiness feature while we deploy it using the deployer/numaresource-operator

Signed-off-by: Talor Itzhak <titzhak@redhat.com>