### PR TITLE
scheduler: allow to specify namespace

### DIFF
--- a/pkg/manifests/sched/sched.go
+++ b/pkg/manifests/sched/sched.go
@@ -79,6 +79,7 @@ func (mf Manifests) Clone() Manifests {
 type UpdateOptions struct {
 	Replicas         int32
 	PullIfNotPresent bool
+	Namespace        string
 }
 
 func (mf Manifests) Update(logger tlog.Logger, options UpdateOptions) Manifests {
@@ -94,6 +95,10 @@ func (mf Manifests) Update(logger tlog.Logger, options UpdateOptions) Manifests 
 	manifests.UpdateSchedulerPluginControllerDeployment(ret.DPController, options.PullIfNotPresent)
 	if mf.plat == platform.OpenShift {
 		ret.Namespace.Name = NamespaceOpenShift
+	}
+
+	if options.Namespace != "" {
+		ret.Namespace.Name = options.Namespace
 	}
 
 	ret.SAController.Namespace = ret.Namespace.Name


### PR DESCRIPTION
This change is good in general, but also will help with implementing the scheduler deployment in NROP.
The change is completely optional and won't affect the default behavior

Signed-off-by: Talor Itzhak <titzhak@redhat.com>