### PR TITLE
cleanup: rename the misleading "update" api

### DIFF
--- a/pkg/commands/render.go
+++ b/pkg/commands/render.go
@@ -65,7 +65,7 @@ func NewRenderAPICommand(commonOpts *CommonOptions, opts *renderOptions) *cobra.
 			if err != nil {
 				return err
 			}
-			return renderObjects(apiManifests.Update().ToObjects())
+			return renderObjects(apiManifests.Render().ToObjects())
 		},
 		Args: cobra.NoArgs,
 	}
@@ -91,12 +91,12 @@ func NewRenderSchedulerPluginCommand(commonOpts *CommonOptions, opts *renderOpti
 				return err
 			}
 
-			updateOpts := sched.UpdateOptions{
+			renderOpts := sched.RenderOptions{
 				Replicas:         int32(commonOpts.Replicas),
 				PullIfNotPresent: commonOpts.PullIfNotPresent,
 			}
 			la := tlog.NewLogAdapter(commonOpts.Log, commonOpts.DebugLog)
-			return renderObjects(schedManifests.Update(la, updateOpts).ToObjects())
+			return renderObjects(schedManifests.Render(la, renderOpts).ToObjects())
 		},
 		Args: cobra.NoArgs,
 	}
@@ -132,7 +132,7 @@ func makeRTEObjects(commonOpts *CommonOptions) ([]client.Object, string, error) 
 	if err != nil {
 		return nil, namespace, err
 	}
-	mf = mf.Update(rtemanifests.UpdateOptions{
+	mf = mf.Render(rtemanifests.RenderOptions{
 		ConfigData:       commonOpts.RTEConfigData,
 		PullIfNotPresent: commonOpts.PullIfNotPresent,
 		Namespace:        namespace,
@@ -149,7 +149,7 @@ func renderManifests(cmd *cobra.Command, commonOpts *CommonOptions, opts *render
 	if err != nil {
 		return err
 	}
-	objs = append(objs, apiManifests.Update().ToObjects()...)
+	objs = append(objs, apiManifests.Render().ToObjects()...)
 
 	rteObjs, rteNs, err := makeRTEObjects(commonOpts)
 	if err != nil {
@@ -162,13 +162,13 @@ func renderManifests(cmd *cobra.Command, commonOpts *CommonOptions, opts *render
 		return err
 	}
 
-	schedUpdateOpts := sched.UpdateOptions{
+	schedRenderOpts := sched.RenderOptions{
 		Replicas:         int32(commonOpts.Replicas),
 		PullIfNotPresent: commonOpts.PullIfNotPresent,
 	}
 
 	la := tlog.NewLogAdapter(commonOpts.Log, commonOpts.DebugLog)
-	objs = append(objs, schedManifests.Update(la, schedUpdateOpts).ToObjects()...)
+	objs = append(objs, schedManifests.Render(la, schedRenderOpts).ToObjects()...)
 
 	return renderObjects(objs)
 }

--- a/pkg/deployer/rte/rte.go
+++ b/pkg/deployer/rte/rte.go
@@ -54,7 +54,7 @@ func Deploy(log tlog.Logger, opts Options) error {
 	if err != nil {
 		return err
 	}
-	mf = mf.Update(rtemanifests.UpdateOptions{
+	mf = mf.Render(rtemanifests.RenderOptions{
 		ConfigData:       opts.RTEConfigData,
 		PullIfNotPresent: opts.PullIfNotPresent,
 		Namespace:        namespace,
@@ -104,7 +104,7 @@ func Remove(log tlog.Logger, opts Options) error {
 	if err != nil {
 		return err
 	}
-	mf = mf.Update(rtemanifests.UpdateOptions{
+	mf = mf.Render(rtemanifests.RenderOptions{
 		ConfigData:       opts.RTEConfigData,
 		PullIfNotPresent: opts.PullIfNotPresent,
 		Namespace:        namespace,

--- a/pkg/deployer/sched/sched.go
+++ b/pkg/deployer/sched/sched.go
@@ -48,7 +48,7 @@ func Deploy(log tlog.Logger, opts Options) error {
 		return err
 	}
 
-	mf = mf.Update(log, schedmanifests.UpdateOptions{
+	mf = mf.Render(log, schedmanifests.RenderOptions{
 		Replicas:         opts.Replicas,
 		PullIfNotPresent: opts.PullIfNotPresent,
 	})
@@ -84,7 +84,7 @@ func Remove(log tlog.Logger, opts Options) error {
 		return err
 	}
 
-	mf = mf.Update(log, schedmanifests.UpdateOptions{
+	mf = mf.Render(log, schedmanifests.RenderOptions{
 		Replicas:         opts.Replicas,
 		PullIfNotPresent: opts.PullIfNotPresent,
 	})

--- a/pkg/manifests/api/api.go
+++ b/pkg/manifests/api/api.go
@@ -59,7 +59,7 @@ func (mf Manifests) Clone() Manifests {
 	}
 }
 
-func (mf Manifests) Update() Manifests {
+func (mf Manifests) Render() Manifests {
 	ret := mf.Clone()
 	// nothing to do atm
 	return ret

--- a/pkg/manifests/rte/rte.go
+++ b/pkg/manifests/rte/rte.go
@@ -74,7 +74,7 @@ func (mf Manifests) Clone() Manifests {
 	return ret
 }
 
-type UpdateOptions struct {
+type RenderOptions struct {
 	// DaemonSet options
 	PullIfNotPresent bool
 	NodeSelector     *metav1.LabelSelector
@@ -90,7 +90,7 @@ type UpdateOptions struct {
 	Name      string
 }
 
-func (mf Manifests) Update(options UpdateOptions) Manifests {
+func (mf Manifests) Render(options RenderOptions) Manifests {
 	ret := mf.Clone()
 	if ret.plat == platform.Kubernetes {
 		if options.Namespace != "" {

--- a/pkg/manifests/rte/rte_test.go
+++ b/pkg/manifests/rte/rte_test.go
@@ -35,7 +35,7 @@ func TestClone(t *testing.T) {
 	}
 }
 
-func TestUpdate(t *testing.T) {
+func TestRender(t *testing.T) {
 	type testCase struct {
 		name string
 		mf   Manifests
@@ -56,7 +56,7 @@ func TestUpdate(t *testing.T) {
 	for _, tc := range testCases {
 		tc.mf, _ = GetManifests(tc.plat, "")
 		mfBeforeUpdate := tc.mf.Clone()
-		uMf := tc.mf.Update(UpdateOptions{})
+		uMf := tc.mf.Render(RenderOptions{})
 
 		if &uMf == &tc.mf {
 			t.Errorf("testcase %q, Update() should return a pristine copy of Manifests object, thus should have different addresses", tc.name)

--- a/pkg/manifests/sched/sched.go
+++ b/pkg/manifests/sched/sched.go
@@ -76,12 +76,12 @@ func (mf Manifests) Clone() Manifests {
 	}
 }
 
-type UpdateOptions struct {
+type RenderOptions struct {
 	Replicas         int32
 	PullIfNotPresent bool
 }
 
-func (mf Manifests) Update(logger tlog.Logger, options UpdateOptions) Manifests {
+func (mf Manifests) Render(logger tlog.Logger, options RenderOptions) Manifests {
 	ret := mf.Clone()
 	replicas := options.Replicas
 	if replicas <= 0 {

--- a/pkg/manifests/updates.go
+++ b/pkg/manifests/updates.go
@@ -20,36 +20,32 @@ const (
 	RTEConfigMapName   = "rte-config"
 )
 
-func UpdateRoleBinding(rb *rbacv1.RoleBinding, serviceAccount, namespace string) *rbacv1.RoleBinding {
+func UpdateRoleBinding(rb *rbacv1.RoleBinding, serviceAccount, namespace string) {
 	for idx := 0; idx < len(rb.Subjects); idx++ {
 		if serviceAccount != "" {
 			rb.Subjects[idx].Name = serviceAccount
 		}
 		rb.Subjects[idx].Namespace = namespace
 	}
-	return rb
 }
 
-func UpdateClusterRoleBinding(crb *rbacv1.ClusterRoleBinding, serviceAccount, namespace string) *rbacv1.ClusterRoleBinding {
+func UpdateClusterRoleBinding(crb *rbacv1.ClusterRoleBinding, serviceAccount, namespace string) {
 	for idx := 0; idx < len(crb.Subjects); idx++ {
 		if serviceAccount != "" {
 			crb.Subjects[idx].Name = serviceAccount
 		}
 		crb.Subjects[idx].Namespace = namespace
 	}
-	return crb
 }
 
-func UpdateSchedulerPluginSchedulerDeployment(dp *appsv1.Deployment, pullIfNotPresent bool) *appsv1.Deployment {
+func UpdateSchedulerPluginSchedulerDeployment(dp *appsv1.Deployment, pullIfNotPresent bool) {
 	dp.Spec.Template.Spec.Containers[0].Image = images.SchedulerPluginSchedulerImage
 	dp.Spec.Template.Spec.Containers[0].ImagePullPolicy = pullPolicy(pullIfNotPresent)
-	return dp
 }
 
-func UpdateSchedulerPluginControllerDeployment(dp *appsv1.Deployment, pullIfNotPresent bool) *appsv1.Deployment {
+func UpdateSchedulerPluginControllerDeployment(dp *appsv1.Deployment, pullIfNotPresent bool) {
 	dp.Spec.Template.Spec.Containers[0].Image = images.SchedulerPluginControllerImage
 	dp.Spec.Template.Spec.Containers[0].ImagePullPolicy = pullPolicy(pullIfNotPresent)
-	return dp
 }
 
 func UpdateResourceTopologyExporterContainerConfig(podSpec *corev1.PodSpec, cnt *corev1.Container, configMapName string) {

--- a/test/e2e/positive.go
+++ b/test/e2e/positive.go
@@ -199,7 +199,7 @@ var _ = ginkgo.Describe("[PositiveFlow] Deployer execution", func() {
 
 			mf, err := rte.GetManifests(platform.Kubernetes, ns.Name)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			mf = mf.Update(rte.UpdateOptions{
+			mf = mf.Render(rte.RenderOptions{
 				Namespace: ns.Name,
 			})
 			e2epods.WaitPodsToBeRunningByRegex(fmt.Sprintf("%s-*", mf.DaemonSet.Name))
@@ -208,7 +208,7 @@ var _ = ginkgo.Describe("[PositiveFlow] Deployer execution", func() {
 			mfs, err := sched.GetManifests(platform.Kubernetes, ns.Name)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			// no need for options!
-			mfs = mfs.Update(tlog.NewNullLogAdapter(), sched.UpdateOptions{})
+			mfs = mfs.Render(tlog.NewNullLogAdapter(), sched.RenderOptions{})
 			e2epods.WaitPodsToBeRunningByRegex(fmt.Sprintf("%s-*", mfs.DPScheduler.Name))
 
 			ginkgo.By("checking that noderesourcetopolgy has some information in it")


### PR DESCRIPTION
We had the unfortunate choice of name of "update" which was misleading and wrong. The intent of the code was to render manifests, not to update them. Fix the API accordingly.