### PR TITLE
manifests: rte: split args from command

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -373,8 +373,11 @@ func DaemonSet(component string, plat platform.Platform, namespace string) (*app
 		c := &ds.Spec.Template.Spec.Containers[i]
 		if c.Name == containerNameRTE {
 			c.Image = images.ResourceTopologyExporterImage
+			// we do this explicitely, but should be already OK from the YAML manifest
 			c.Command = []string{
 				"/bin/resource-topology-exporter",
+			}
+			c.Args = []string{
 				"--sleep-interval=10s",
 				fmt.Sprintf("--sysfs=%s", containerHostSysDir),
 				fmt.Sprintf("--podresources-socket=unix://%s", containerPodResourcesSocket),
@@ -382,8 +385,8 @@ func DaemonSet(component string, plat platform.Platform, namespace string) (*app
 			}
 
 			if plat == platform.OpenShift {
-				c.Command = append(
-					c.Command,
+				c.Args = append(
+					c.Args,
 					// TODO: we should fetch the policy from the KubeletConfig CR
 					"--topology-manager-policy=single-numa-node",
 				)
@@ -400,8 +403,8 @@ func DaemonSet(component string, plat platform.Platform, namespace string) (*app
 			}
 
 			if plat == platform.Kubernetes {
-				c.Command = append(
-					c.Command,
+				c.Args = append(
+					c.Args,
 					fmt.Sprintf("--kubelet-config-file=/%s/config.yaml", rteKubeletDirVolumeName),
 					fmt.Sprintf("--kubelet-state-dir=/%s", rteKubeletDirVolumeName),
 				)

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -546,7 +546,7 @@ func TestDaemonSet(t *testing.T) {
 				}
 			}
 
-			containerCommand := strings.Join(rteContainer.Command, " ")
+			containerCommand := strings.Join(rteContainer.Args, " ")
 			for _, arg := range tc.expectedCommandArgs {
 				if !strings.Contains(containerCommand, arg) {
 					t.Fatalf("the container command %q does not container argument %q", containerCommand, arg)

--- a/pkg/manifests/yaml/rte/daemonset.yaml
+++ b/pkg/manifests/yaml/rte/daemonset.yaml
@@ -20,6 +20,7 @@ spec:
         image: ${RTE_CONTAINER_IMAGE}
         command:
         - /bin/resource-topology-exporter
+        args:
         - --sleep-interval=${RTE_POLL_INTERVAL}
         - --sysfs=/host-sys
         - --podresources-socket=unix:///host-var/lib/kubelet/pod-resources/kubelet.sock


### PR DESCRIPTION
Per the documentation:
```
When you create a Pod, you can define a command and arguments for the containers that run in the Pod.
To define a command, include the `command` field in the configuration file. To define arguments for
the command, include the `args` field in the configuration file.
The command and arguments that you define cannot be changed after the Pod is created.
```
(see:
https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/
see also:
https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#notes)

The most correct and precise form is thus to supply *both* `command` and
`args` - and that was the original intent of the manifest; conveying
everything into the `command` is a slightly abuse, even if this works.

Signed-off-by: Francesco Romani <fromani@redhat.com>