### PR TITLE
release: render manifests using deployer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,11 +50,17 @@ jobs:
       run: |
         _out/e2e.test -ginkgo.focus='\[PositiveFlow\]'
 
+    - name: render manifests
+      run: |
+        make release-manifests-k8s
+
     - name: fix build artifacts
       run: |
         mv _out/deployer deployer-${{ env.RELEASE_VERSION }}-linux-amd64
+        mv _out/deployer-manifests-allinone.yaml deployer-manifests-allinone-${{ env.RELEASE_VERSION }}.yaml
         make clean outdir
         mv deployer-${{ env.RELEASE_VERSION}}-linux-amd64 _out/
+        mv deployer-manifests-allinone-${{ env.RELEASE_VERSION}}.yaml _out/
 
     - name: compute signature
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,15 +56,12 @@ jobs:
 
     - name: fix build artifacts
       run: |
-        mv _out/deployer deployer-${{ env.RELEASE_VERSION }}-linux-amd64
-        mv _out/deployer-manifests-allinone.yaml deployer-manifests-allinone-${{ env.RELEASE_VERSION }}.yaml
-        make clean outdir
-        mv deployer-${{ env.RELEASE_VERSION}}-linux-amd64 _out/
-        mv deployer-manifests-allinone-${{ env.RELEASE_VERSION}}.yaml _out/
+        cp _out/deployer _out/deployer-${{ env.RELEASE_VERSION }}-linux-amd64
+        cp _out/deployer-manifests-allinone.yaml _out/deployer-manifests-allinone-${{ env.RELEASE_VERSION }}.yaml
 
     - name: compute signature
       run: |
-        pushd _out && sha256sum * >> ../SHA256SUMS && mv ../SHA256SUMS . && popd
+        hack/make-checksum.sh ${{ env.RELEASE_VERSION }}
 
     - name: upload build artifacts
       uses: actions/upload-artifact@v2

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,10 @@ deployer: outdir update-version
 outdir:
 	@mkdir -p _out || :
 
+.PHONY: release-manifests
+release-manifests-k8s: deployer
+	@_out/deployer -P kubernetes render > _out/deployer-manifests-allinone.yaml
+
 .PHONY: test-unit
 test-unit:
 	go test ./pkg/...

--- a/hack/make-checksum.sh
+++ b/hack/make-checksum.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -eu
+
+VERSION="${1}"
+FILES="
+deployer-${VERSION}-linux-amd64
+deployer-manifests-allinone-${VERSION}.yaml
+"
+
+for artifact in $FILES; do
+	if [ ! -f "_out/${artifact}" ]; then
+		echo "MISSING: ${artifact}" >&2
+		exit 1
+	fi
+done
+
+pushd _out
+:> SHA256SUMS
+sha256sum ${FILES} >> SHA256SUMS
+popd


### PR DESCRIPTION
Use the `deployer` binary built as release artifact to generate (and add to released artifact) the manifests.
This enables users interested only in released manifests to download them right away, instead of being force to download the deployer binary first.

Closes: https://github.com/k8stopologyawareschedwg/deployer/issues/81

Signed-off-by: Francesco Romani <fromani@redhat.com>