### PR TITLE
Deploy NFD as topology-updater component

### DIFF
--- a/pkg/commands/deploy.go
+++ b/pkg/commands/deploy.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/api"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
-	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/rte"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/sched"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/updaters"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/tlog"
 
 	"github.com/spf13/cobra"
@@ -74,11 +74,11 @@ func NewRemoveCommand(commonOpts *CommonOptions) *cobra.Command {
 				// intentionally keep going to remove as much as possible
 				la.Printf("error removing: %v", err)
 			}
-			err = rte.Remove(la, rte.Options{
+			err = updaters.Remove(la, commonOpts.UpdaterType, updaters.Options{
 				Platform:         opts.clusterPlatform,
 				WaitCompletion:   opts.waitCompletion,
-				RTEConfigData:    commonOpts.RTEConfigData,
 				PullIfNotPresent: commonOpts.PullIfNotPresent,
+				RTEConfigData:    commonOpts.RTEConfigData,
 			})
 			if err != nil {
 				// intentionally keep going to remove as much as possible
@@ -157,11 +157,11 @@ func NewDeployTopologyUpdaterCommand(commonOpts *CommonOptions, opts *deployOpti
 			if opts.clusterPlatform == platform.Unknown {
 				return fmt.Errorf("cannot autodetect the platform, and no platform given")
 			}
-			return rte.Deploy(la, rte.Options{
+			return updaters.Deploy(la, commonOpts.UpdaterType, updaters.Options{
 				Platform:         opts.clusterPlatform,
 				WaitCompletion:   opts.waitCompletion,
-				RTEConfigData:    commonOpts.RTEConfigData,
 				PullIfNotPresent: commonOpts.PullIfNotPresent,
+				RTEConfigData:    commonOpts.RTEConfigData,
 			})
 		},
 		Args: cobra.NoArgs,
@@ -225,11 +225,11 @@ func NewRemoveTopologyUpdaterCommand(commonOpts *CommonOptions, opts *deployOpti
 			if opts.clusterPlatform == platform.Unknown {
 				return fmt.Errorf("cannot autodetect the platform, and no platform given")
 			}
-			return rte.Remove(la, rte.Options{
+			return updaters.Remove(la, commonOpts.UpdaterType, updaters.Options{
 				Platform:         opts.clusterPlatform,
 				WaitCompletion:   opts.waitCompletion,
-				RTEConfigData:    commonOpts.RTEConfigData,
 				PullIfNotPresent: commonOpts.PullIfNotPresent,
+				RTEConfigData:    commonOpts.RTEConfigData,
 			})
 		},
 		Args: cobra.NoArgs,
@@ -249,11 +249,11 @@ func deployOnCluster(commonOpts *CommonOptions, opts *deployOptions) error {
 	}); err != nil {
 		return err
 	}
-	if err := rte.Deploy(la, rte.Options{
+	if err := updaters.Deploy(la, commonOpts.UpdaterType, updaters.Options{
 		Platform:         opts.clusterPlatform,
 		WaitCompletion:   opts.waitCompletion,
-		RTEConfigData:    commonOpts.RTEConfigData,
 		PullIfNotPresent: commonOpts.PullIfNotPresent,
+		RTEConfigData:    commonOpts.RTEConfigData,
 	}); err != nil {
 		return err
 	}

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/updaters"
 )
 
 type CommonOptions struct {
@@ -35,6 +36,7 @@ type CommonOptions struct {
 	Replicas         int
 	RTEConfigData    string
 	PullIfNotPresent bool
+	UpdaterType      string
 	rteConfigFile    string
 	plat             string
 }
@@ -74,6 +76,9 @@ func NewRootCommand(extraCmds ...NewCommandFunc) *cobra.Command {
 				commonOpts.RTEConfigData = string(data)
 				commonOpts.DebugLog.Printf("RTE config: read %d bytes", len(commonOpts.RTEConfigData))
 			}
+			if err := validateUpdaterType(commonOpts.UpdaterType); err != nil {
+				return err
+			}
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -88,6 +93,7 @@ func NewRootCommand(extraCmds ...NewCommandFunc) *cobra.Command {
 	root.PersistentFlags().IntVarP(&commonOpts.Replicas, "replicas", "R", 1, "set the replica value - where relevant.")
 	root.PersistentFlags().BoolVar(&commonOpts.PullIfNotPresent, "pull-if-not-present", false, "force pull policies to IfNotPresent.")
 	root.PersistentFlags().StringVar(&commonOpts.rteConfigFile, "rte-config-file", "", "inject rte configuration reading from this file.")
+	root.PersistentFlags().StringVar(&commonOpts.UpdaterType, "updater-type", "RTE", "type of updater to deploy - RTE or NFD")
 
 	root.AddCommand(
 		NewRenderCommand(commonOpts),
@@ -104,4 +110,11 @@ func NewRootCommand(extraCmds ...NewCommandFunc) *cobra.Command {
 	}
 
 	return root
+}
+
+func validateUpdaterType(updaterType string) error {
+	if updaterType != updaters.RTE && updaterType != updaters.NFD {
+		return fmt.Errorf("%q is invalid updater type", updaterType)
+	}
+	return nil
 }

--- a/pkg/deployer/updaters/objects.go
+++ b/pkg/deployer/updaters/objects.go
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ */
+
+package updaters
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer"
+	nfdmanifests "github.com/k8stopologyawareschedwg/deployer/pkg/manifests/nfd"
+	rtemanifests "github.com/k8stopologyawareschedwg/deployer/pkg/manifests/rte"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/tlog"
+)
+
+func GetObjects(opts Options, updaterType, namespace string) ([]client.Object, error) {
+	if updaterType == RTE {
+		mf, err := rtemanifests.GetManifests(opts.Platform, namespace)
+		if err != nil {
+			return nil, err
+		}
+		return mf.Render(rteOptionsFrom(opts, namespace)).ToObjects(), nil
+	}
+	if updaterType == NFD {
+		mf, err := nfdmanifests.GetManifests(opts.Platform, namespace)
+		if err != nil {
+			return nil, err
+		}
+		return mf.Render(nfdOptionsFrom(opts, namespace)).ToObjects(), nil
+	}
+	return nil, fmt.Errorf("unsupported updater: %q", updaterType)
+}
+
+func getCreatableObjects(opts Options, hp *deployer.Helper, log tlog.Logger, updaterType, namespace string) ([]deployer.WaitableObject, error) {
+	if updaterType == RTE {
+		mf, err := rtemanifests.GetManifests(opts.Platform, namespace)
+		if err != nil {
+			return nil, err
+		}
+		return mf.Render(rteOptionsFrom(opts, namespace)).ToCreatableObjects(hp, log), nil
+	}
+	if updaterType == NFD {
+		mf, err := nfdmanifests.GetManifests(opts.Platform, namespace)
+		if err != nil {
+			return nil, err
+		}
+		return mf.Render(nfdOptionsFrom(opts, namespace)).ToCreatableObjects(hp, log), nil
+	}
+	return nil, fmt.Errorf("unsupported updater: %q", updaterType)
+}
+
+func getDeletableObjects(opts Options, hp *deployer.Helper, log tlog.Logger, updaterType, namespace string) ([]deployer.WaitableObject, error) {
+	if updaterType == RTE {
+		mf, err := rtemanifests.GetManifests(opts.Platform, namespace)
+		if err != nil {
+			return nil, err
+		}
+		return mf.Render(rteOptionsFrom(opts, namespace)).ToDeletableObjects(hp, log), nil
+	}
+	if updaterType == NFD {
+		mf, err := nfdmanifests.GetManifests(opts.Platform, namespace)
+		if err != nil {
+			return nil, err
+		}
+		return mf.Render(nfdOptionsFrom(opts, namespace)).ToDeletableObjects(hp, log), nil
+	}
+	return nil, fmt.Errorf("unsupported updater: %q", updaterType)
+}
+
+func rteOptionsFrom(opts Options, namespace string) rtemanifests.RenderOptions {
+	return rtemanifests.RenderOptions{
+		ConfigData:       opts.RTEConfigData,
+		PullIfNotPresent: opts.PullIfNotPresent,
+		Namespace:        namespace,
+	}
+}
+
+func nfdOptionsFrom(opts Options, namespace string) nfdmanifests.RenderOptions {
+	return nfdmanifests.RenderOptions{
+		PullIfNotPresent: opts.PullIfNotPresent,
+		Namespace:        namespace,
+	}
+}

--- a/pkg/images/consts.go
+++ b/pkg/images/consts.go
@@ -20,10 +20,12 @@ const (
 	SchedulerPluginSchedulerDefaultImageTag  = "quay.io/k8stopologyawareschedwg/scheduler-plugins-kube-scheduler:v0.0.2021112403"
 	SchedulerPluginControllerDefaultImageTag = "quay.io/k8stopologyawareschedwg/scheduler-plugins-controller:v0.0.2021112403"
 	ResourceTopologyExporterDefaultImageTag  = "quay.io/k8stopologyawareschedwg/resource-topology-exporter:v0.3.1"
+	NodeFeatureDiscoveryDefaultImageTag      = "gcr.io/k8s-staging-nfd/node-feature-discovery:v0.10.1"
 )
 
 const (
 	SchedulerPluginSchedulerDefaultImageSHA  = "quay.io/k8stopologyawareschedwg/scheduler-plugins-kube-scheduler@sha256:c885039e4cceb19ba3acbc12a7a56846cd0a0c8a69bbe185abcd6124df51b056"
 	SchedulerPluginControllerDefaultImageSHA = "quay.io/k8stopologyawareschedwg/scheduler-plugins-controller@sha256:4d0111cafb1320e260f5ebe7531c742e4b3617fbdb9d30510321237615cf3e1c"
 	ResourceTopologyExporterDefaultImageSHA  = "quay.io/k8stopologyawareschedwg/resource-topology-exporter@sha256:93c4a41ce90dc7c4e286f8d1ba262405f20582f970992e7daee702ece1b6f3ad"
+	NodeFeatureDiscoveryDefaultImageSHA      = "gcr.io/k8s-staging-nfd/node-feature-discovery@sha256:4aebf17c8b72ee91cb468a6f21dd9f0312c1fcfdf8c86341f7aee0ec2d5991d7"
 )

--- a/pkg/images/consts_test.go
+++ b/pkg/images/consts_test.go
@@ -29,4 +29,7 @@ func TestImageURISanity(t *testing.T) {
 	if ResourceTopologyExporterImage == "" {
 		t.Fatalf("invalid Resource Topology Exporter Image pull URL")
 	}
+	if NodeFeatureDiscoveryImage == "" {
+		t.Fatalf("invalid Node Feature Discovery Image pull URL")
+	}
 }

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -28,10 +28,14 @@ func init() {
 	if rteImage, ok := os.LookupEnv("TAS_RESOURCE_EXPORTER_IMAGE"); ok {
 		ResourceTopologyExporterImage = rteImage
 	}
+	if nfdImage, ok := os.LookupEnv("TAS_NODE_FEATURE_DISCOVERY_IMAGE"); ok {
+		NodeFeatureDiscoveryImage = nfdImage
+	}
 }
 
 var (
 	SchedulerPluginSchedulerImage  = SchedulerPluginSchedulerDefaultImageTag
 	SchedulerPluginControllerImage = SchedulerPluginSchedulerDefaultImageTag
 	ResourceTopologyExporterImage  = ResourceTopologyExporterDefaultImageTag
+	NodeFeatureDiscoveryImage      = NodeFeatureDiscoveryDefaultImageTag
 )

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -309,120 +309,121 @@ func DaemonSet(component, subComponent string, plat platform.Platform, namespace
 		return nil, fmt.Errorf("unexpected type, got %t", obj)
 	}
 
-	hostPathDirectory := corev1.HostPathDirectory
-	hostPathSocket := corev1.HostPathSocket
-	hostPathDirectoryOrCreate := corev1.HostPathDirectoryOrCreate
-	ds.Spec.Template.Spec.Volumes = []corev1.Volume{
-		{
-			// needed to get the CPU, PCI devices and memory information
-			Name: rteSysVolumeName,
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/sys",
-					Type: &hostPathDirectory,
-				},
-			},
-		},
-		{
-			Name: rtePodresourcesSocketVolumeName,
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/var/lib/kubelet/pod-resources/kubelet.sock",
-					Type: &hostPathSocket,
-				},
-			},
-		},
-		{
-			// notifier file volume
-			Name: rteNotifierVolumeName,
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: hostNotifierDir,
-					Type: &hostPathDirectoryOrCreate,
-				},
-			},
-		},
-	}
-
-	containerPodResourcesSocket := filepath.Join("/", rtePodresourcesSocketVolumeName, "kubelet.sock")
-	containerHostSysDir := filepath.Join("/", rteSysVolumeName)
-	rteContainerVolumeMounts := []corev1.VolumeMount{
-		{
-			Name:      rteSysVolumeName,
-			ReadOnly:  true,
-			MountPath: containerHostSysDir,
-		},
-		{
-			Name:      rtePodresourcesSocketVolumeName,
-			MountPath: containerPodResourcesSocket,
-		},
-		{
-			Name:      rteNotifierVolumeName,
-			MountPath: filepath.Join("/", rteNotifierVolumeName),
-		},
-	}
-
-	if plat == platform.Kubernetes {
-		ds.Spec.Template.Spec.Volumes = append(ds.Spec.Template.Spec.Volumes,
-			corev1.Volume{
-				Name: rteKubeletDirVolumeName,
+	if component == ComponentResourceTopologyExporter {
+		hostPathDirectory := corev1.HostPathDirectory
+		hostPathSocket := corev1.HostPathSocket
+		hostPathDirectoryOrCreate := corev1.HostPathDirectoryOrCreate
+		ds.Spec.Template.Spec.Volumes = []corev1.Volume{
+			{
+				// needed to get the CPU, PCI devices and memory information
+				Name: rteSysVolumeName,
 				VolumeSource: corev1.VolumeSource{
 					HostPath: &corev1.HostPathVolumeSource{
-						Path: "/var/lib/kubelet",
+						Path: "/sys",
 						Type: &hostPathDirectory,
 					},
 				},
 			},
-		)
-		rteContainerVolumeMounts = append(rteContainerVolumeMounts, corev1.VolumeMount{
-			Name:      rteKubeletDirVolumeName,
-			ReadOnly:  true,
-			MountPath: filepath.Join("/", rteKubeletDirVolumeName),
-		})
-	}
+			{
+				Name: rtePodresourcesSocketVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: "/var/lib/kubelet/pod-resources/kubelet.sock",
+						Type: &hostPathSocket,
+					},
+				},
+			},
+			{
+				// notifier file volume
+				Name: rteNotifierVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: hostNotifierDir,
+						Type: &hostPathDirectoryOrCreate,
+					},
+				},
+			},
+		}
 
-	for i := range ds.Spec.Template.Spec.Containers {
-		c := &ds.Spec.Template.Spec.Containers[i]
-		if c.Name == containerNameRTE {
-			c.Image = images.ResourceTopologyExporterImage
-			// we do this explicitely, but should be already OK from the YAML manifest
-			c.Command = []string{
-				"/bin/resource-topology-exporter",
-			}
-			c.Args = []string{
-				"--sleep-interval=10s",
-				fmt.Sprintf("--sysfs=%s", containerHostSysDir),
-				fmt.Sprintf("--podresources-socket=unix://%s", containerPodResourcesSocket),
-				fmt.Sprintf("--notify-file=/%s/%s", rteNotifierVolumeName, rteNotifierFileName),
-			}
+		containerPodResourcesSocket := filepath.Join("/", rtePodresourcesSocketVolumeName, "kubelet.sock")
+		containerHostSysDir := filepath.Join("/", rteSysVolumeName)
+		rteContainerVolumeMounts := []corev1.VolumeMount{
+			{
+				Name:      rteSysVolumeName,
+				ReadOnly:  true,
+				MountPath: containerHostSysDir,
+			},
+			{
+				Name:      rtePodresourcesSocketVolumeName,
+				MountPath: containerPodResourcesSocket,
+			},
+			{
+				Name:      rteNotifierVolumeName,
+				MountPath: filepath.Join("/", rteNotifierVolumeName),
+			},
+		}
+		if plat == platform.Kubernetes {
+			ds.Spec.Template.Spec.Volumes = append(ds.Spec.Template.Spec.Volumes,
+				corev1.Volume{
+					Name: rteKubeletDirVolumeName,
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/var/lib/kubelet",
+							Type: &hostPathDirectory,
+						},
+					},
+				},
+			)
+			rteContainerVolumeMounts = append(rteContainerVolumeMounts, corev1.VolumeMount{
+				Name:      rteKubeletDirVolumeName,
+				ReadOnly:  true,
+				MountPath: filepath.Join("/", rteKubeletDirVolumeName),
+			})
+		}
 
-			if plat == platform.OpenShift {
-				c.Args = append(
-					c.Args,
-					// TODO: we should fetch the policy from the KubeletConfig CR
-					"--topology-manager-policy=single-numa-node",
-				)
-
-				// this is needed to put watches in the kubelet state dirs AND
-				// to open the podresources socket in R/W mode
-				if c.SecurityContext == nil {
-					c.SecurityContext = &corev1.SecurityContext{}
+		for i := range ds.Spec.Template.Spec.Containers {
+			c := &ds.Spec.Template.Spec.Containers[i]
+			if c.Name == containerNameRTE {
+				c.Image = images.ResourceTopologyExporterImage
+				// we do this explicitely, but should be already OK from the YAML manifest
+				c.Command = []string{
+					"/bin/resource-topology-exporter",
 				}
-				c.SecurityContext.SELinuxOptions = &corev1.SELinuxOptions{
-					Type:  seLinuxRTEContextType,
-					Level: seLinuxRTEContextLevel,
+				c.Args = []string{
+					"--sleep-interval=10s",
+					fmt.Sprintf("--sysfs=%s", containerHostSysDir),
+					fmt.Sprintf("--podresources-socket=unix://%s", containerPodResourcesSocket),
+					fmt.Sprintf("--notify-file=/%s/%s", rteNotifierVolumeName, rteNotifierFileName),
 				}
-			}
 
-			if plat == platform.Kubernetes {
-				c.Args = append(
-					c.Args,
-					fmt.Sprintf("--kubelet-config-file=/%s/config.yaml", rteKubeletDirVolumeName),
-					fmt.Sprintf("--kubelet-state-dir=/%s", rteKubeletDirVolumeName),
-				)
-			}
+				if plat == platform.OpenShift {
+					c.Args = append(
+						c.Args,
+						// TODO: we should fetch the policy from the KubeletConfig CR
+						"--topology-manager-policy=single-numa-node",
+					)
 
-			c.VolumeMounts = rteContainerVolumeMounts
+					// this is needed to put watches in the kubelet state dirs AND
+					// to open the podresources socket in R/W mode
+					if c.SecurityContext == nil {
+						c.SecurityContext = &corev1.SecurityContext{}
+					}
+					c.SecurityContext.SELinuxOptions = &corev1.SELinuxOptions{
+						Type:  seLinuxRTEContextType,
+						Level: seLinuxRTEContextLevel,
+					}
+				}
+
+				if plat == platform.Kubernetes {
+					c.Args = append(
+						c.Args,
+						fmt.Sprintf("--kubelet-config-file=/%s/config.yaml", rteKubeletDirVolumeName),
+						fmt.Sprintf("--kubelet-state-dir=/%s", rteKubeletDirVolumeName),
+					)
+				}
+
+				c.VolumeMounts = rteContainerVolumeMounts
+			}
 		}
 	}
 
@@ -640,7 +641,7 @@ func loadObject(path string) (runtime.Object, error) {
 }
 
 func validateComponent(component string) error {
-	if component == "api" || component == "rte" || component == "nfd" || component == "sched" {
+	if component == ComponentAPI || component == ComponentResourceTopologyExporter || component == ComponentNodeFeatureDiscovery || component == ComponentSchedulerPlugin {
 		return nil
 	}
 	return fmt.Errorf("unknown component: %q", component)
@@ -650,11 +651,35 @@ func validateSubComponent(component, subComponent string) error {
 	if subComponent == "" {
 		return nil
 	}
-	if component == "sched" && (subComponent == "controller" || subComponent == "scheduler") {
+	if component == ComponentSchedulerPlugin && (subComponent == SubComponentSchedulerPluginController || subComponent == SubComponentSchedulerPluginScheduler) {
 		return nil
 	}
-	if component == "nfd" && (subComponent == "topologyupdater" || subComponent == "master") {
+	if component == ComponentNodeFeatureDiscovery && (subComponent == SubComponentNodeFeatureDiscoveryTopologyUpdater || subComponent == SubComponentNodeFeatureDiscoveryMaster) {
 		return nil
 	}
 	return fmt.Errorf("unknown subComponent %q for component: %q", subComponent, component)
+}
+
+func Service(component, subComponent, namespace string) (*corev1.Service, error) {
+	if err := validateComponent(component); err != nil {
+		return nil, err
+	}
+	if err := validateSubComponent(component, subComponent); err != nil {
+		return nil, err
+	}
+
+	obj, err := loadObject(filepath.Join("yaml", component, subComponent, "service.yaml"))
+	if err != nil {
+		return nil, err
+	}
+
+	sv, ok := obj.(*corev1.Service)
+	if !ok {
+		return nil, fmt.Errorf("unexpected type, got %t", obj)
+	}
+
+	if namespace != "" {
+		sv.Namespace = namespace
+	}
+	return sv, nil
 }

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -391,7 +391,7 @@ func TestGetDeployment(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.component, func(t *testing.T) {
-			obj, err := Deployment(tc.component, tc.subComponent)
+			obj, err := Deployment(tc.component, tc.subComponent, "")
 			if tc.expectError {
 				if err == nil || obj != nil {
 					t.Fatalf("nil err or non-nil obj=%v", obj)
@@ -407,8 +407,9 @@ func TestGetDeployment(t *testing.T) {
 
 func TestGetDaemonSet(t *testing.T) {
 	type testCase struct {
-		component   string
-		expectError bool
+		component    string
+		subComponent string
+		expectError  bool
 	}
 
 	testCases := []testCase{
@@ -432,7 +433,7 @@ func TestGetDaemonSet(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.component, func(t *testing.T) {
-			_, err := DaemonSet(tc.component, platform.Kubernetes, "")
+			_, err := DaemonSet(tc.component, tc.subComponent, platform.Kubernetes, "")
 			if (err != nil) != tc.expectError {
 				t.Fatalf("nil obj or non-nil err=%v", err)
 			}
@@ -499,7 +500,7 @@ func TestDaemonSet(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ds, err := DaemonSet(ComponentResourceTopologyExporter, tc.plat, "test")
+			ds, err := DaemonSet(ComponentResourceTopologyExporter, "", tc.plat, "test")
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/pkg/manifests/nfd/nfd.go
+++ b/pkg/manifests/nfd/nfd.go
@@ -1,0 +1,214 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ */
+
+package nfd
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/wait"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/manifests"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/tlog"
+)
+
+type Manifests struct {
+	Namespace *corev1.Namespace
+	// master objects
+	SAMaster  *corev1.ServiceAccount
+	CRMaster  *rbacv1.ClusterRole
+	CRBMaster *rbacv1.ClusterRoleBinding
+	DPMaster  *appsv1.Deployment
+	SVMaster  *corev1.Service
+
+	// topology-updater objects
+	SATopologyUpdater  *corev1.ServiceAccount
+	CRTopologyUpdater  *rbacv1.ClusterRole
+	CRBTopologyUpdater *rbacv1.ClusterRoleBinding
+	DSTopologyUpdater  *appsv1.DaemonSet
+
+	plat platform.Platform
+}
+
+func (mf Manifests) Clone() Manifests {
+	ret := Manifests{
+		plat: mf.plat,
+
+		Namespace: mf.Namespace.DeepCopy(),
+		// master objects
+		CRMaster:  mf.CRMaster.DeepCopy(),
+		CRBMaster: mf.CRBMaster.DeepCopy(),
+		DPMaster:  mf.DPMaster.DeepCopy(),
+		SAMaster:  mf.SAMaster.DeepCopy(),
+		SVMaster:  mf.SVMaster.DeepCopy(),
+
+		// topology-updater objects
+		CRTopologyUpdater:  mf.CRTopologyUpdater.DeepCopy(),
+		CRBTopologyUpdater: mf.CRBTopologyUpdater.DeepCopy(),
+		DSTopologyUpdater:  mf.DSTopologyUpdater.DeepCopy(),
+		SATopologyUpdater:  mf.SATopologyUpdater.DeepCopy(),
+	}
+
+	return ret
+}
+
+type RenderOptions struct {
+	PullIfNotPresent bool
+	// DaemonSet option
+	NodeSelector *metav1.LabelSelector
+	// Deployment option
+	Replicas int32
+
+	// General options
+	Namespace string
+}
+
+func (mf Manifests) Render(options RenderOptions) Manifests {
+	ret := mf.Clone()
+
+	replicas := options.Replicas
+	if replicas <= 0 {
+		replicas = int32(1)
+	}
+	ret.DPMaster.Spec.Replicas = &replicas
+
+	if options.Namespace != "" {
+		ret.Namespace.Name = options.Namespace
+	}
+
+	manifests.UpdateClusterRoleBinding(ret.CRBMaster, mf.SAMaster.Name, ret.Namespace.Name)
+	manifests.UpdateClusterRoleBinding(ret.CRBTopologyUpdater, mf.SATopologyUpdater.Name, ret.Namespace.Name)
+
+	ret.DPMaster.Spec.Template.Spec.ServiceAccountName = mf.SAMaster.Name
+	ret.DSTopologyUpdater.Spec.Template.Spec.ServiceAccountName = mf.SATopologyUpdater.Name
+
+	manifests.UpdateNFDMasterDeployment(ret.DPMaster, options.PullIfNotPresent)
+	manifests.UpdateNFDTopologyUpdaterDaemonSet(ret.DSTopologyUpdater, options.PullIfNotPresent, options.NodeSelector)
+
+	return ret
+}
+
+func (mf Manifests) ToObjects() []client.Object {
+	return []client.Object{
+		mf.Namespace,
+		// master objects
+		mf.CRMaster,
+		mf.CRBMaster,
+		mf.SAMaster,
+		mf.DPMaster,
+		mf.SVMaster,
+		// topology-updater objects
+		mf.SATopologyUpdater,
+		mf.CRTopologyUpdater,
+		mf.CRBTopologyUpdater,
+		mf.DSTopologyUpdater,
+	}
+}
+
+func (mf Manifests) ToCreatableObjects(hp *deployer.Helper, log tlog.Logger) []deployer.WaitableObject {
+	return []deployer.WaitableObject{
+		{Obj: mf.CRMaster},
+		{Obj: mf.CRBMaster},
+		{Obj: mf.SAMaster},
+		{Obj: mf.SVMaster},
+		{
+			Obj: mf.DPMaster,
+			Wait: func() error {
+				return wait.PodsToBeRunningByRegex(hp, log, mf.DPMaster.Namespace, mf.DPMaster.Name)
+			},
+		},
+		{Obj: mf.SATopologyUpdater},
+		{Obj: mf.CRTopologyUpdater},
+		{Obj: mf.CRBTopologyUpdater},
+		{
+			Obj: mf.DSTopologyUpdater,
+			Wait: func() error {
+				return wait.PodsToBeRunningByRegex(hp, log, mf.DSTopologyUpdater.Namespace, mf.DSTopologyUpdater.Name)
+			},
+		},
+	}
+}
+
+func (mf Manifests) ToDeletableObjects(hp *deployer.Helper, log tlog.Logger) []deployer.WaitableObject {
+	return []deployer.WaitableObject{
+		{Obj: mf.CRBTopologyUpdater},
+		{Obj: mf.CRTopologyUpdater},
+		{Obj: mf.CRBMaster},
+		{Obj: mf.CRMaster},
+	}
+}
+
+func New(plat platform.Platform) Manifests {
+	mf := Manifests{
+		plat: plat,
+	}
+
+	return mf
+}
+
+func GetManifests(plat platform.Platform, namespace string) (Manifests, error) {
+	var err error
+	mf := New(plat)
+
+	mf.Namespace, err = manifests.Namespace(manifests.ComponentNodeFeatureDiscovery)
+	if err != nil {
+		return mf, err
+	}
+
+	mf.SAMaster, err = manifests.ServiceAccount(manifests.ComponentNodeFeatureDiscovery, manifests.SubComponentNodeFeatureDiscoveryMaster, namespace)
+	if err != nil {
+		return mf, err
+	}
+	mf.CRMaster, err = manifests.ClusterRole(manifests.ComponentNodeFeatureDiscovery, manifests.SubComponentNodeFeatureDiscoveryMaster)
+	if err != nil {
+		return mf, err
+	}
+	mf.CRBMaster, err = manifests.ClusterRoleBinding(manifests.ComponentNodeFeatureDiscovery, manifests.SubComponentNodeFeatureDiscoveryMaster)
+	if err != nil {
+		return mf, err
+	}
+	mf.DPMaster, err = manifests.Deployment(manifests.ComponentNodeFeatureDiscovery, manifests.SubComponentNodeFeatureDiscoveryMaster, namespace)
+	if err != nil {
+		return mf, err
+	}
+	mf.SATopologyUpdater, err = manifests.ServiceAccount(manifests.ComponentNodeFeatureDiscovery, manifests.SubComponentNodeFeatureDiscoveryTopologyUpdater, namespace)
+	if err != nil {
+		return mf, err
+	}
+	mf.CRTopologyUpdater, err = manifests.ClusterRole(manifests.ComponentNodeFeatureDiscovery, manifests.SubComponentNodeFeatureDiscoveryTopologyUpdater)
+	if err != nil {
+		return mf, err
+	}
+	mf.CRBTopologyUpdater, err = manifests.ClusterRoleBinding(manifests.ComponentNodeFeatureDiscovery, manifests.SubComponentNodeFeatureDiscoveryTopologyUpdater)
+	if err != nil {
+		return mf, err
+	}
+	mf.DSTopologyUpdater, err = manifests.DaemonSet(manifests.ComponentNodeFeatureDiscovery, manifests.SubComponentNodeFeatureDiscoveryTopologyUpdater, plat, namespace)
+	if err != nil {
+		return mf, err
+	}
+	mf.SVMaster, err = manifests.Service(manifests.ComponentNodeFeatureDiscovery, manifests.SubComponentNodeFeatureDiscoveryMaster, namespace)
+	if err != nil {
+		return mf, err
+	}
+
+	return mf, nil
+}

--- a/pkg/manifests/nfd/nfd_test.go
+++ b/pkg/manifests/nfd/nfd_test.go
@@ -14,7 +14,7 @@
  * Copyright 2021 Red Hat, Inc.
  */
 
-package rte
+package nfd
 
 import (
 	"reflect"
@@ -23,6 +23,45 @@ import (
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
 )
 
+const defaultNFDNamespace = "node-feature-discovery"
+
+func TestGetManifests(t *testing.T) {
+	type testCase struct {
+		name      string
+		namespace string
+		mf        Manifests
+		plat      platform.Platform
+	}
+
+	testCases := []testCase{
+		{
+			name:      "kubernetes manifests",
+			namespace: "k8s-test-ns",
+			plat:      platform.Kubernetes,
+		},
+		{
+			name: "kubernetes manifests with default namespace",
+			plat: platform.Kubernetes,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc.mf, _ = GetManifests(tc.plat, tc.namespace)
+		for _, obj := range tc.mf.ToObjects() {
+			if tc.namespace != "" {
+				if obj.GetNamespace() != "" && obj.GetNamespace() != tc.namespace {
+					t.Errorf("testcase %q, GetManifests failed to create %q object named %q with correct namespace %q. got namespace %q instead ",
+						tc.name, obj.GetObjectKind(), obj.GetName(), tc.namespace, obj.GetNamespace())
+				}
+			} else { // no namespace provided we should have the default
+				if obj.GetNamespace() != "" && obj.GetNamespace() != defaultNFDNamespace {
+					t.Errorf("testcase %q, GetManifests failed to create %q object named %q with default namespace %q. got namespace %q instead ",
+						tc.name, obj.GetObjectKind(), obj.GetName(), defaultNFDNamespace, obj.GetNamespace())
+				}
+			}
+		}
+	}
+}
 func TestClone(t *testing.T) {
 	type testCase struct {
 		name string
@@ -71,33 +110,14 @@ func TestRender(t *testing.T) {
 
 	for _, tc := range testCases {
 		tc.mf, _ = GetManifests(tc.plat, "")
-		mfBeforeRender := tc.mf.Clone()
+		mfBeforeUpdate := tc.mf.Clone()
 		uMf := tc.mf.Render(RenderOptions{})
 
 		if &uMf == &tc.mf {
 			t.Errorf("testcase %q, Render() should return a pristine copy of Manifests object, thus should have different addresses", tc.name)
 		}
-		if !reflect.DeepEqual(mfBeforeRender, tc.mf) {
+		if !reflect.DeepEqual(mfBeforeUpdate, tc.mf) {
 			t.Errorf("testcase %q, Render() should not modify the original Manifests object", tc.name)
 		}
-	}
-}
-
-func TestGetManifestsOpenShift(t *testing.T) {
-	mf, err := GetManifests(platform.OpenShift, "test")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if mf.SecurityContextConstraint == nil {
-		t.Fatalf("no security context constraint is generated for the OpenShift platform")
-	}
-
-	if mf.MachineConfig == nil {
-		t.Fatalf("no machine config is generated for the OpenShift platform")
-	}
-
-	if mf.DaemonSet == nil {
-		t.Fatalf("no daemon set is generated for the OpenShift platform")
 	}
 }

--- a/pkg/manifests/rte/rte.go
+++ b/pkg/manifests/rte/rte.go
@@ -281,7 +281,7 @@ func GetManifests(plat platform.Platform, namespace string) (Manifests, error) {
 	if err != nil {
 		return mf, err
 	}
-	mf.DaemonSet, err = manifests.DaemonSet(manifests.ComponentResourceTopologyExporter, plat, namespace)
+	mf.DaemonSet, err = manifests.DaemonSet(manifests.ComponentResourceTopologyExporter, "", plat, namespace)
 	if err != nil {
 		return mf, err
 	}

--- a/pkg/manifests/sched/sched.go
+++ b/pkg/manifests/sched/sched.go
@@ -211,7 +211,7 @@ func GetManifests(plat platform.Platform, namespace string) (Manifests, error) {
 	if err != nil {
 		return mf, err
 	}
-	mf.DPScheduler, err = manifests.Deployment(manifests.ComponentSchedulerPlugin, manifests.SubComponentSchedulerPluginScheduler)
+	mf.DPScheduler, err = manifests.Deployment(manifests.ComponentSchedulerPlugin, manifests.SubComponentSchedulerPluginScheduler, "")
 	if err != nil {
 		return mf, err
 	}
@@ -232,7 +232,7 @@ func GetManifests(plat platform.Platform, namespace string) (Manifests, error) {
 	if err != nil {
 		return mf, err
 	}
-	mf.DPController, err = manifests.Deployment(manifests.ComponentSchedulerPlugin, manifests.SubComponentSchedulerPluginController)
+	mf.DPController, err = manifests.Deployment(manifests.ComponentSchedulerPlugin, manifests.SubComponentSchedulerPluginController, "")
 	if err != nil {
 		return mf, err
 	}

--- a/pkg/manifests/updates.go
+++ b/pkg/manifests/updates.go
@@ -89,6 +89,30 @@ func UpdateResourceTopologyExporterDaemonSet(ds *appsv1.DaemonSet, configMapName
 	UpdateMetricsPort(ds, metricsPort)
 }
 
+func UpdateNFDTopologyUpdaterDaemonSet(ds *appsv1.DaemonSet, pullIfNotPresent bool, nodeSelector *metav1.LabelSelector) {
+	for i := range ds.Spec.Template.Spec.Containers {
+		c := &ds.Spec.Template.Spec.Containers[i]
+		if c.Name != containerNameNFDTopologyUpdater {
+			continue
+		}
+		c.ImagePullPolicy = pullPolicy(pullIfNotPresent)
+
+	}
+	if nodeSelector != nil {
+		ds.Spec.Template.Spec.NodeSelector = nodeSelector.MatchLabels
+	}
+}
+
+func UpdateNFDMasterDeployment(ds *appsv1.Deployment, pullIfNotPresent bool) {
+	for i := range ds.Spec.Template.Spec.Containers {
+		c := &ds.Spec.Template.Spec.Containers[i]
+		if c.Name != containerNameNFDMaster {
+			continue
+		}
+		c.ImagePullPolicy = pullPolicy(pullIfNotPresent)
+	}
+}
+
 func UpdateMachineConfig(mc *machineconfigv1.MachineConfig, name string, mcpSelector *metav1.LabelSelector) {
 	if name != "" {
 		mc.Name = fmt.Sprintf("51-%s", name)

--- a/pkg/manifests/updates.go
+++ b/pkg/manifests/updates.go
@@ -96,6 +96,7 @@ func UpdateNFDTopologyUpdaterDaemonSet(ds *appsv1.DaemonSet, pullIfNotPresent bo
 			continue
 		}
 		c.ImagePullPolicy = pullPolicy(pullIfNotPresent)
+		c.Image = images.NodeFeatureDiscoveryImage
 
 	}
 	if nodeSelector != nil {
@@ -110,6 +111,7 @@ func UpdateNFDMasterDeployment(ds *appsv1.Deployment, pullIfNotPresent bool) {
 			continue
 		}
 		c.ImagePullPolicy = pullPolicy(pullIfNotPresent)
+		c.Image = images.NodeFeatureDiscoveryImage
 	}
 }
 

--- a/pkg/manifests/updates_test.go
+++ b/pkg/manifests/updates_test.go
@@ -17,6 +17,8 @@
 package manifests
 
 import (
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -137,5 +139,101 @@ func TestAddConfigMapToPod(t *testing.T) {
 	}
 	if len(pod.Spec.Volumes) != 1 {
 		t.Errorf("missing volume declaration")
+	}
+}
+
+func TestUpdateNFDTopologyUpdaterDaemonSet(t *testing.T) {
+	ds := &appsv1.DaemonSet{
+		Spec: appsv1.DaemonSetSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{},
+					},
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		cntName          string
+		pullIfNotPresent bool
+		nodeSelector     *metav1.LabelSelector
+	}{
+		{
+			cntName:          containerNameNFDTopologyUpdater,
+			pullIfNotPresent: false,
+			nodeSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"foo": "bar"},
+			},
+		},
+		{
+			cntName:          containerNameNFDMaster,
+			pullIfNotPresent: true,
+			nodeSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"foo": "bar"},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		mutatedDs := ds.DeepCopy()
+		pSpec := &mutatedDs.Spec.Template.Spec
+		pSpec.Containers[0].Name = tc.cntName
+		UpdateNFDTopologyUpdaterDaemonSet(mutatedDs, tc.pullIfNotPresent, tc.nodeSelector)
+		if tc.cntName == containerNameNFDTopologyUpdater {
+			if pSpec.Containers[0].ImagePullPolicy != pullPolicy(tc.pullIfNotPresent) {
+				t.Errorf("expected container ImagePullPolicy to be: %q; got: %q", pullPolicy(tc.pullIfNotPresent), pSpec.Containers[0].ImagePullPolicy)
+			}
+			if !cmp.Equal(pSpec.NodeSelector, tc.nodeSelector.MatchLabels) {
+				t.Errorf("expected NodeSelector to be: %v; got: %v", tc.nodeSelector.MatchLabels, pSpec.NodeSelector)
+			}
+		} else {
+			if pSpec.Containers[0].ImagePullPolicy != "" {
+				t.Errorf("container name is other than %q, no changes to container are expected", containerNameNFDTopologyUpdater)
+			}
+		}
+	}
+}
+
+func TestUpdateNFDMasterDeployment(t *testing.T) {
+	dp := &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{},
+					},
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		cntName          string
+		pullIfNotPresent bool
+	}{
+		{
+			cntName:          containerNameNFDMaster,
+			pullIfNotPresent: true,
+		},
+		{
+			cntName:          "foo",
+			pullIfNotPresent: true,
+		},
+	}
+	for _, tc := range testCases {
+		mutatedDp := dp.DeepCopy()
+		pSpec := &mutatedDp.Spec.Template.Spec
+		pSpec.Containers[0].Name = tc.cntName
+		UpdateNFDMasterDeployment(mutatedDp, tc.pullIfNotPresent)
+		if tc.cntName == containerNameNFDMaster {
+			if pSpec.Containers[0].ImagePullPolicy != pullPolicy(tc.pullIfNotPresent) {
+				t.Errorf("expected container ImagePullPolicy to be: %q; got: %q", pullPolicy(tc.pullIfNotPresent), pSpec.Containers[0].ImagePullPolicy)
+			}
+		} else {
+			if pSpec.Containers[0].ImagePullPolicy != "" {
+				t.Errorf("container name is other than %q, no changes to container are expected", containerNameNFDMaster)
+			}
+		}
 	}
 }

--- a/pkg/manifests/yaml/nfd/master/clusterrole.yaml
+++ b/pkg/manifests/yaml/nfd/master/clusterrole.yaml
@@ -1,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nfd-master
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - patch
+      - update
+      - list
+  - apiGroups:
+      - topology.node.k8s.io
+    resources:
+      - noderesourcetopologies
+    verbs:
+      - create
+      - get
+      - update
+  - apiGroups:
+      - nfd.k8s-sigs.io
+    resources:
+      - nodefeaturerules
+    verbs:
+      - get
+      - list
+      - watch

--- a/pkg/manifests/yaml/nfd/master/clusterrolebinding.yaml
+++ b/pkg/manifests/yaml/nfd/master/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nfd-master
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nfd-master
+subjects:
+- kind: ServiceAccount
+  name: nfd-master
+  namespace: node-feature-discovery

--- a/pkg/manifests/yaml/nfd/master/deployment.yaml
+++ b/pkg/manifests/yaml/nfd/master/deployment.yaml
@@ -1,0 +1,80 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: nfd
+  name: nfd-master
+  namespace: node-feature-discovery
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nfd-master
+  template:
+    metadata:
+      labels:
+        app: nfd-master
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - preference:
+                matchExpressions:
+                  - key: node-role.kubernetes.io/master
+                    operator: In
+                    values:
+                      - ""
+              weight: 1
+            - preference:
+                matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: In
+                    values:
+                      - ""
+              weight: 1
+      containers:
+        - args: []
+          command:
+            - nfd-master
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          image: ${NFD_CONTAINER_IMAGE}
+          imagePullPolicy: Always
+          livenessProbe:
+            exec:
+              command:
+                - /usr/bin/grpc_health_probe
+                - -addr=:8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          name: nfd-master
+          readinessProbe:
+            exec:
+              command:
+                - /usr/bin/grpc_health_probe
+                - -addr=:8080
+            failureThreshold: 10
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          volumeMounts: []
+      serviceAccount: nfd-master
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Equal
+          value: ""
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+          operator: Equal
+          value: ""
+      volumes: []

--- a/pkg/manifests/yaml/nfd/master/service.yaml
+++ b/pkg/manifests/yaml/nfd/master/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nfd-master
+  namespace: node-feature-discovery
+spec:
+  ports:
+    - port: 8080
+      protocol: TCP
+  selector:
+    app: nfd-master
+  type: ClusterIP

--- a/pkg/manifests/yaml/nfd/master/serviceaccount.yaml
+++ b/pkg/manifests/yaml/nfd/master/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nfd-master
+  namespace: node-feature-discovery

--- a/pkg/manifests/yaml/nfd/namespace.yaml
+++ b/pkg/manifests/yaml/nfd/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: node-feature-discovery

--- a/pkg/manifests/yaml/nfd/topologyupdater/clusterrole.yaml
+++ b/pkg/manifests/yaml/nfd/topologyupdater/clusterrole.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nfd-topology-updater
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get

--- a/pkg/manifests/yaml/nfd/topologyupdater/clusterrolebinding.yaml
+++ b/pkg/manifests/yaml/nfd/topologyupdater/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nfd-topology-updater
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nfd-topology-updater
+subjects:
+- kind: ServiceAccount
+  name: nfd-topology-updater
+  namespace: node-feature-discovery
+
+

--- a/pkg/manifests/yaml/nfd/topologyupdater/daemonset.yaml
+++ b/pkg/manifests/yaml/nfd/topologyupdater/daemonset.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: nfd
+  name: nfd-topology-updater
+  namespace: node-feature-discovery
+spec:
+  selector:
+    matchLabels:
+      app: nfd-topology-updater
+  template:
+    metadata:
+      labels:
+        app: nfd-topology-updater
+    spec:
+      containers:
+        - args:
+            - -server=nfd-master:8080
+            - -kubelet-config-file=/host-var/lib/kubelet/config.yaml
+            - -podresources-socket=/host-var/lib/kubelet/pod-resources/kubelet.sock
+            - -sleep-interval=10s
+          command:
+            - nfd-topology-updater
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          image: ${NFD_CONTAINER_IMAGE}
+          imagePullPolicy: Always
+          name: nfd-topology-updater
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsUser: 0
+          volumeMounts:
+            - mountPath: /host-var/lib/kubelet/config.yaml
+              name: kubelet-podresources-conf
+            - mountPath: /host-var/lib/kubelet/pod-resources/kubelet.sock
+              name: kubelet-podresources-sock
+            - mountPath: /host-sys
+              name: host-sys
+      dnsPolicy: ClusterFirstWithHostNet
+      serviceAccount: nfd-topology-updater
+      volumes:
+        - hostPath:
+            path: /sys
+          name: host-sys
+        - hostPath:
+            path: /var/lib/kubelet/config.yaml
+          name: kubelet-podresources-conf
+        - hostPath:
+            path: /var/lib/kubelet/pod-resources/kubelet.sock
+          name: kubelet-podresources-sock

--- a/pkg/manifests/yaml/nfd/topologyupdater/machineconfig.yaml
+++ b/pkg/manifests/yaml/nfd/topologyupdater/machineconfig.yaml
@@ -1,0 +1,8 @@
+# To update the SELinux policy you will need to decode the source content via base64, update it and encode back
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: 50-nfd-topology-updater
+  labels:
+    machineconfiguration.openshift.io/role:  worker
+spec: {} # we will inject here the SELinux policy and the systemd service to install it

--- a/pkg/manifests/yaml/nfd/topologyupdater/securitycontextconstraint.yaml
+++ b/pkg/manifests/yaml/nfd/topologyupdater/securitycontextconstraint.yaml
@@ -1,0 +1,16 @@
+# TODO: check if we can reduce scc capabilities
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: nfd-topology-updater
+allowHostDirVolumePlugin: true
+fsGroup:
+  type: RunAsAny
+readOnlyRootFilesystem: false
+runAsUser:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+users: []
+volumes:
+- '*'

--- a/pkg/manifests/yaml/nfd/topologyupdater/serviceaccount.yaml
+++ b/pkg/manifests/yaml/nfd/topologyupdater/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nfd-topology-updater
+  namespace: node-feature-discovery


### PR DESCRIPTION
This change will allow deployer to deploy NFD as the topology-updater component.
NFD is the u/s version of RTE, thus it's is important to have the ability to use it.

The default topology-updater component is still RTE since it's more mature and tested for quite some time.

- [x] Refactor the code to allow easier integration for NFD component
- [x]  Add NFD component
- [x] Add unit-tests
- [x] Add E2E tests

This PR provides NFD support only for K8S.
We'll add support for OCP in the future when NFD will catch up with RTE (from abilities perspective) 