### PR TITLE
pkg: manifests: cleanup useless fields

### DIFF
--- a/pkg/manifests/codec.go
+++ b/pkg/manifests/codec.go
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ */
+
+package manifests
+
+import (
+	"encoding/json"
+	"io"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+func SerializeObject(obj runtime.Object, out io.Writer) error {
+	jsonBytes, err := json.Marshal(obj)
+	if err != nil {
+		return err
+	}
+
+	var r unstructured.Unstructured
+	if err := json.Unmarshal(jsonBytes, &r.Object); err != nil {
+		return err
+	}
+
+	// remove status and metadata.creationTimestamp
+	unstructured.RemoveNestedField(r.Object, "metadata", "creationTimestamp")
+	unstructured.RemoveNestedField(r.Object, "template", "metadata", "creationTimestamp")
+	unstructured.RemoveNestedField(r.Object, "spec", "template", "metadata", "creationTimestamp")
+	unstructured.RemoveNestedField(r.Object, "status")
+
+	srz := k8sjson.NewYAMLSerializer(k8sjson.DefaultMetaFactory, scheme.Scheme, scheme.Scheme)
+	return srz.Encode(&r, out)
+}
+
+func deserializeObjectFromData(data []byte) (runtime.Object, error) {
+	decode := scheme.Codecs.UniversalDeserializer().Decode
+	obj, _, err := decode(data, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+func loadObject(path string) (runtime.Object, error) {
+	data, err := src.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return deserializeObjectFromData(data)
+}

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -22,7 +22,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io"
 	"path/filepath"
 	"text/template"
 
@@ -34,7 +33,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	k8sjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/client-go/kubernetes/scheme"
 	kubeschedulerconfigv1beta1 "k8s.io/kube-scheduler/config/v1beta1"
 	"k8s.io/utils/pointer"
@@ -603,28 +601,6 @@ func NodeResourceTopologyMatchArgsToData(ma *apiconfig.NodeResourceTopologyMatch
 		Namespaces:     ma.Namespaces,
 	}
 	return json.Marshal(cfg)
-}
-
-func SerializeObject(obj runtime.Object, out io.Writer) error {
-	srz := k8sjson.NewYAMLSerializer(k8sjson.DefaultMetaFactory, scheme.Scheme, scheme.Scheme)
-	return srz.Encode(obj, out)
-}
-
-func deserializeObjectFromData(data []byte) (runtime.Object, error) {
-	decode := scheme.Codecs.UniversalDeserializer().Decode
-	obj, _, err := decode(data, nil, nil)
-	if err != nil {
-		return nil, err
-	}
-	return obj, nil
-}
-
-func loadObject(path string) (runtime.Object, error) {
-	data, err := src.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-	return deserializeObjectFromData(data)
 }
 
 func validateComponent(component string) error {


### PR DESCRIPTION
Let's remove fields which doesn't make sense
as render target, because they are managed by the cluster
and thus are ignored anyway when we submit the manifests,
like status and creationTimestamps.

Signed-off-by: Francesco Romani <fromani@redhat.com>