### PR TITLE
assets: notifier: use absolute path

### DIFF
--- a/pkg/assets/rte/rte-notifier.sh
+++ b/pkg/assets/rte/rte-notifier.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 
-notifier_file="${1}"
-bundle=$(jq -r '.bundle' /dev/stdin 2>&1)
-pod_cgroup=$(jq .linux.cgroupsPath < ${bundle}/config.json)
+JQ="/usr/bin/jq"
+NOTIFIER_FILE="${1}"
+
+bundle=$( ${JQ} -r '.bundle' /dev/stdin 2>&1 )
+pod_cgroup=$( ${JQ} .linux.cgroupsPath < ${bundle}/config.json )
 
 # Do not touch file for non guaranteed pods
 if [[ ${pod_cgroup} =~ ".*burstable.*" ]] || [[ ${pod_cgroup} =~ ".*besteffort.*" ]]; then
     exit 0
 fi
 
-touch "${notifier_file}" || :
+touch "${NOTIFIER_FILE}" || :


### PR DESCRIPTION
Use absolute path for jq. Even though `/usr/bin/jq` is not always
guaranteed to be correct, it is still better than depending on $PATH
when running as OCI hook.

Plus, in the most common container OSes, the jq path _is_ actually
/usr.bin/jq. Point in case, this is especially true for OCP, the only
platform on which we deploy and recommend this hook anyway.

Signed-off-by: Francesco Romani <fromani@redhat.com>