### PR TITLE
pkg: commands: refactor commands to make them reusable

### DIFF
--- a/pkg/commands/deploy.go
+++ b/pkg/commands/deploy.go
@@ -28,13 +28,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type deployOptions struct {
+type DeployOptions struct {
 	clusterPlatform platform.Platform
 	waitCompletion  bool
 }
 
 func NewDeployCommand(commonOpts *CommonOptions) *cobra.Command {
-	opts := &deployOptions{}
+	opts := &DeployOptions{}
 	deploy := &cobra.Command{
 		Use:   "deploy",
 		Short: "deploy the components and configurations needed for topology-aware-scheduling",
@@ -51,7 +51,7 @@ func NewDeployCommand(commonOpts *CommonOptions) *cobra.Command {
 }
 
 func NewRemoveCommand(commonOpts *CommonOptions) *cobra.Command {
-	opts := &deployOptions{}
+	opts := &DeployOptions{}
 	remove := &cobra.Command{
 		Use:   "remove",
 		Short: "remove the components and configurations needed for topology-aware-scheduling",
@@ -102,7 +102,7 @@ func NewRemoveCommand(commonOpts *CommonOptions) *cobra.Command {
 	return remove
 }
 
-func NewDeployAPICommand(commonOpts *CommonOptions, opts *deployOptions) *cobra.Command {
+func NewDeployAPICommand(commonOpts *CommonOptions, opts *DeployOptions) *cobra.Command {
 	deploy := &cobra.Command{
 		Use:   "api",
 		Short: "deploy the APIs needed for topology-aware-scheduling",
@@ -123,7 +123,7 @@ func NewDeployAPICommand(commonOpts *CommonOptions, opts *deployOptions) *cobra.
 	return deploy
 }
 
-func NewDeploySchedulerPluginCommand(commonOpts *CommonOptions, opts *deployOptions) *cobra.Command {
+func NewDeploySchedulerPluginCommand(commonOpts *CommonOptions, opts *DeployOptions) *cobra.Command {
 	deploy := &cobra.Command{
 		Use:   "scheduler-plugin",
 		Short: "deploy the scheduler plugin needed for topology-aware-scheduling",
@@ -146,7 +146,7 @@ func NewDeploySchedulerPluginCommand(commonOpts *CommonOptions, opts *deployOpti
 	return deploy
 }
 
-func NewDeployTopologyUpdaterCommand(commonOpts *CommonOptions, opts *deployOptions) *cobra.Command {
+func NewDeployTopologyUpdaterCommand(commonOpts *CommonOptions, opts *DeployOptions) *cobra.Command {
 	deploy := &cobra.Command{
 		Use:   "topology-updater",
 		Short: "deploy the topology updater needed for topology-aware-scheduling",
@@ -169,7 +169,7 @@ func NewDeployTopologyUpdaterCommand(commonOpts *CommonOptions, opts *deployOpti
 	return deploy
 }
 
-func NewRemoveAPICommand(commonOpts *CommonOptions, opts *deployOptions) *cobra.Command {
+func NewRemoveAPICommand(commonOpts *CommonOptions, opts *DeployOptions) *cobra.Command {
 	remove := &cobra.Command{
 		Use:   "api",
 		Short: "remove the APIs needed for topology-aware-scheduling",
@@ -191,7 +191,7 @@ func NewRemoveAPICommand(commonOpts *CommonOptions, opts *deployOptions) *cobra.
 	return remove
 }
 
-func NewRemoveSchedulerPluginCommand(commonOpts *CommonOptions, opts *deployOptions) *cobra.Command {
+func NewRemoveSchedulerPluginCommand(commonOpts *CommonOptions, opts *DeployOptions) *cobra.Command {
 	remove := &cobra.Command{
 		Use:   "scheduler-plugin",
 		Short: "remove the scheduler plugin needed for topology-aware-scheduling",
@@ -214,7 +214,7 @@ func NewRemoveSchedulerPluginCommand(commonOpts *CommonOptions, opts *deployOpti
 	return remove
 }
 
-func NewRemoveTopologyUpdaterCommand(commonOpts *CommonOptions, opts *deployOptions) *cobra.Command {
+func NewRemoveTopologyUpdaterCommand(commonOpts *CommonOptions, opts *DeployOptions) *cobra.Command {
 	remove := &cobra.Command{
 		Use:   "topology-updater",
 		Short: "remove the topology updater needed for topology-aware-scheduling",
@@ -237,7 +237,7 @@ func NewRemoveTopologyUpdaterCommand(commonOpts *CommonOptions, opts *deployOpti
 	return remove
 }
 
-func deployOnCluster(commonOpts *CommonOptions, opts *deployOptions) error {
+func deployOnCluster(commonOpts *CommonOptions, opts *DeployOptions) error {
 	la := tlog.NewLogAdapter(commonOpts.Log, commonOpts.DebugLog)
 	platDetect := detectPlatform(commonOpts.DebugLog, commonOpts.UserPlatform)
 	opts.clusterPlatform = platDetect.Discovered

--- a/pkg/commands/images.go
+++ b/pkg/commands/images.go
@@ -28,13 +28,13 @@ import (
 	"github.com/k8stopologyawareschedwg/deployer/pkg/images"
 )
 
-type imagesOptions struct {
+type ImagesOptions struct {
 	jsonOutput bool
 	rawOutput  bool
 }
 
 func NewImagesCommand(commonOpts *CommonOptions) *cobra.Command {
-	opts := &imagesOptions{}
+	opts := &ImagesOptions{}
 	images := &cobra.Command{
 		Use:   "images",
 		Short: "dump the container images used to deploy",

--- a/pkg/commands/render.go
+++ b/pkg/commands/render.go
@@ -31,10 +31,10 @@ import (
 	"github.com/k8stopologyawareschedwg/deployer/pkg/tlog"
 )
 
-type renderOptions struct{}
+type RenderOptions struct{}
 
 func NewRenderCommand(commonOpts *CommonOptions) *cobra.Command {
-	opts := &renderOptions{}
+	opts := &RenderOptions{}
 	render := &cobra.Command{
 		Use:   "render",
 		Short: "render all the manifests",
@@ -52,7 +52,7 @@ func NewRenderCommand(commonOpts *CommonOptions) *cobra.Command {
 	return render
 }
 
-func NewRenderAPICommand(commonOpts *CommonOptions, opts *renderOptions) *cobra.Command {
+func NewRenderAPICommand(commonOpts *CommonOptions, opts *RenderOptions) *cobra.Command {
 	render := &cobra.Command{
 		Use:   "api",
 		Short: "render the APIs needed for topology-aware-scheduling",
@@ -71,7 +71,7 @@ func NewRenderAPICommand(commonOpts *CommonOptions, opts *renderOptions) *cobra.
 	return render
 }
 
-func NewRenderSchedulerPluginCommand(commonOpts *CommonOptions, opts *renderOptions) *cobra.Command {
+func NewRenderSchedulerPluginCommand(commonOpts *CommonOptions, opts *RenderOptions) *cobra.Command {
 	render := &cobra.Command{
 		Use:   "scheduler-plugin",
 		Short: "render the scheduler plugin needed for topology-aware-scheduling",
@@ -102,7 +102,7 @@ func NewRenderSchedulerPluginCommand(commonOpts *CommonOptions, opts *renderOpti
 	return render
 }
 
-func NewRenderTopologyUpdaterCommand(commonOpts *CommonOptions, opts *renderOptions) *cobra.Command {
+func NewRenderTopologyUpdaterCommand(commonOpts *CommonOptions, opts *RenderOptions) *cobra.Command {
 	render := &cobra.Command{
 		Use:   "topology-updater",
 		Short: "render the topology updater needed for topology-aware-scheduling",
@@ -140,7 +140,7 @@ func makeUpdaterObjects(commonOpts *CommonOptions) ([]client.Object, string, err
 	return append([]client.Object{ns}, objs...), namespace, nil
 }
 
-func renderManifests(cmd *cobra.Command, commonOpts *CommonOptions, opts *renderOptions, args []string) error {
+func renderManifests(cmd *cobra.Command, commonOpts *CommonOptions, opts *RenderOptions, args []string) error {
 	var objs []client.Object
 
 	apiManifests, err := api.GetManifests(commonOpts.UserPlatform)

--- a/pkg/commands/render.go
+++ b/pkg/commands/render.go
@@ -42,7 +42,7 @@ func NewRenderCommand(commonOpts *CommonOptions) *cobra.Command {
 			if commonOpts.UserPlatform == platform.Unknown {
 				return fmt.Errorf("must explicitely select a cluster platform")
 			}
-			return renderManifests(cmd, commonOpts, opts, args)
+			return RenderManifests(commonOpts)
 		},
 		Args: cobra.NoArgs,
 	}
@@ -140,7 +140,7 @@ func makeUpdaterObjects(commonOpts *CommonOptions) ([]client.Object, string, err
 	return append([]client.Object{ns}, objs...), namespace, nil
 }
 
-func renderManifests(cmd *cobra.Command, commonOpts *CommonOptions, opts *RenderOptions, args []string) error {
+func RenderManifests(commonOpts *CommonOptions) error {
 	var objs []client.Object
 
 	apiManifests, err := api.GetManifests(commonOpts.UserPlatform)

--- a/pkg/commands/setup.go
+++ b/pkg/commands/setup.go
@@ -21,7 +21,7 @@ import (
 )
 
 func NewSetupCommand(commonOpts *CommonOptions) *cobra.Command {
-	depOpts := &deployOptions{}
+	depOpts := &DeployOptions{}
 	valOpts := &validateOptions{}
 	setup := &cobra.Command{
 		Use:   "setup",

--- a/test/e2e/negative.go
+++ b/test/e2e/negative.go
@@ -51,3 +51,11 @@ var _ = ginkgo.Describe("[NegativeFlow] Deployer validation", func() {
 		})
 	})
 })
+
+var _ = ginkgo.Describe("[NegativeFlow] Deployer option validation", func() {
+	ginkgo.It("It should fail with invalid --updater-type", func() {
+		updaterType := "LOCAL"
+		err := deploy(updaterType)
+		gomega.Expect(err).To(gomega.HaveOccurred(), "deployed succesfully with unknown updater type %s", updaterType)
+	})
+})


### PR DESCRIPTION
The original intent of the `commands` pkg was to be reusable, to enable clients to inject deployer commands in their own programs. This turns out harder than expected in practice, because of somehow excessive coupling in the `commands` pkg.
This PR relaxes these contraints and make sure that these commands, at least the `render` subtree, is actually reusable in external projects.