### PR TITLE
pkg: detect cluster version alongside platform

### DIFF
--- a/pkg/deployer/platform/platform.go
+++ b/pkg/deployer/platform/platform.go
@@ -30,7 +30,7 @@ func (p Platform) String() string {
 	return string(p)
 }
 
-func FromString(plat string) (Platform, bool) {
+func ParsePlatform(plat string) (Platform, bool) {
 	plat = strings.ToLower(plat)
 	switch plat {
 	case "kubernetes":

--- a/pkg/deployer/platform/version.go
+++ b/pkg/deployer/platform/version.go
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ */
+
+package platform
+
+import goversion "github.com/aquasecurity/go-version/pkg/version"
+
+type Version string
+
+const MissingVersion Version = ""
+
+func ParseVersion(v string) (Version, error) {
+	_, err := goversion.Parse(v)
+	if err != nil {
+		return Version(""), err
+	}
+	return Version(v), nil
+}
+
+func (v Version) String() string {
+	return string(v)
+}
+
+func (v Version) AtLeastString(other string) (bool, error) {
+	ref, err := goversion.Parse(other)
+	if err != nil {
+		return false, err
+	}
+	ser, err := goversion.Parse(v.String())
+	if err != nil {
+		return false, err
+	}
+	return ser.Compare(ref) >= 0, nil
+}
+
+func (v Version) AtLeast(other Version) (bool, error) {
+	return v.AtLeastString(other.String())
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -65,10 +65,21 @@ func (vo validationOutput) String() string {
 	return sb.String()
 }
 
-type detectionOutput struct {
+type platformDetection struct {
 	AutoDetected platform.Platform `json:"auto_detected"`
 	UserSupplied platform.Platform `json:"user_supplied"`
 	Discovered   platform.Platform `json:"discovered"`
+}
+
+type versionDetection struct {
+	AutoDetected platform.Version `json:"auto_detected"`
+	UserSupplied platform.Version `json:"user_supplied"`
+	Discovered   platform.Version `json:"discovered"`
+}
+
+type clusterDetection struct {
+	Platform platformDetection `json:"platform"`
+	Version  versionDetection  `json:"version"`
 }
 
 type imageOutput struct {


### PR DESCRIPTION
We will soon need to support version-specific configuration (e.g. in MachineConfig).
To enable this, we add the concept of platform version (retroactively renaming the current platform as "kind") all across the stack.

This is a API-breaking enablement PR only: consumers of this new data will be added in future PRs.
Signed-off-by: Francesco Romani <fromani@redhat.com>