### PR TITLE
images: RTE: bump to v0.6.0

### DIFF
--- a/pkg/images/consts.go
+++ b/pkg/images/consts.go
@@ -19,13 +19,13 @@ package images
 const (
 	SchedulerPluginSchedulerDefaultImageTag  = "quay.io/k8stopologyawareschedwg/scheduler-plugins-kube-scheduler:v0.0.2021112403"
 	SchedulerPluginControllerDefaultImageTag = "quay.io/k8stopologyawareschedwg/scheduler-plugins-controller:v0.0.2021112403"
-	ResourceTopologyExporterDefaultImageTag  = "quay.io/k8stopologyawareschedwg/resource-topology-exporter:v0.3.1"
+	ResourceTopologyExporterDefaultImageTag  = "quay.io/k8stopologyawareschedwg/resource-topology-exporter:v0.6.0"
 	NodeFeatureDiscoveryDefaultImageTag      = "gcr.io/k8s-staging-nfd/node-feature-discovery:v0.10.1"
 )
 
 const (
 	SchedulerPluginSchedulerDefaultImageSHA  = "quay.io/k8stopologyawareschedwg/scheduler-plugins-kube-scheduler@sha256:c885039e4cceb19ba3acbc12a7a56846cd0a0c8a69bbe185abcd6124df51b056"
 	SchedulerPluginControllerDefaultImageSHA = "quay.io/k8stopologyawareschedwg/scheduler-plugins-controller@sha256:4d0111cafb1320e260f5ebe7531c742e4b3617fbdb9d30510321237615cf3e1c"
-	ResourceTopologyExporterDefaultImageSHA  = "quay.io/k8stopologyawareschedwg/resource-topology-exporter@sha256:93c4a41ce90dc7c4e286f8d1ba262405f20582f970992e7daee702ece1b6f3ad"
+	ResourceTopologyExporterDefaultImageSHA  = "quay.io/k8stopologyawareschedwg/resource-topology-exporter@sha256:c4721e940250ef3a31600e70d4c933551492b22ed54c9593ad2a246da976d6f1"
 	NodeFeatureDiscoveryDefaultImageSHA      = "gcr.io/k8s-staging-nfd/node-feature-discovery@sha256:4aebf17c8b72ee91cb468a6f21dd9f0312c1fcfdf8c86341f7aee0ec2d5991d7"
 )


### PR DESCRIPTION
Previously, we just neglected to update the builtin images, trusting the user to replace them. Time to fix the defaults
to something more modern than ancient 0.3.1, but still compatible with the NRT API 0.0.12.
The scheduler side will be updated with a different PR.
