### PR TITLE
Makefile: catchup with -P changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ outdir:
 
 .PHONY: release-manifests
 release-manifests-k8s: deployer
-	@_out/deployer -P kubernetes render > _out/deployer-manifests-allinone.yaml
+	@_out/deployer -P kubernetes:v1.24 render > _out/deployer-manifests-allinone.yaml
 
 .PHONY: test-unit
 test-unit:


### PR DESCRIPTION
we now require explicitly the platform AND the version,
let's fix the Makefile target - and then the release flow.

Signed-off-by: Francesco Romani <fromani@redhat.com>