### PR TITLE
platform: expose error on autodetection

### DIFF
--- a/pkg/commands/deploy.go
+++ b/pkg/commands/deploy.go
@@ -59,13 +59,13 @@ func NewRemoveCommand(commonOpts *CommonOptions) *cobra.Command {
 		Short: "remove the components and configurations needed for topology-aware-scheduling",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			la := tlog.NewLogAdapter(commonOpts.Log, commonOpts.DebugLog)
-			platDetect, reason := detect.FindPlatform(commonOpts.UserPlatform)
+			platDetect, reason, _ := detect.FindPlatform(commonOpts.UserPlatform)
 			commonOpts.DebugLog.Printf("platform %s (%s)", platDetect.Discovered, reason)
 			opts.clusterPlatform = platDetect.Discovered
 			if opts.clusterPlatform == platform.Unknown {
 				return fmt.Errorf("cannot autodetect the platform, and no platform given")
 			}
-			versionDetect, source := detect.FindVersion(platDetect.Discovered, commonOpts.UserPlatformVersion)
+			versionDetect, source, _ := detect.FindVersion(platDetect.Discovered, commonOpts.UserPlatformVersion)
 			commonOpts.DebugLog.Printf("Version detection source: %s", source)
 			opts.clusterVersion = versionDetect.Discovered
 			if opts.clusterVersion == platform.MissingVersion {
@@ -118,13 +118,13 @@ func NewDeployAPICommand(commonOpts *CommonOptions, opts *DeployOptions) *cobra.
 		Short: "deploy the APIs needed for topology-aware-scheduling",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			la := tlog.NewLogAdapter(commonOpts.Log, commonOpts.DebugLog)
-			platDetect, reason := detect.FindPlatform(commonOpts.UserPlatform)
+			platDetect, reason, _ := detect.FindPlatform(commonOpts.UserPlatform)
 			commonOpts.DebugLog.Printf("platform %s (%s)", platDetect.Discovered, reason)
 			opts.clusterPlatform = platDetect.Discovered
 			if opts.clusterPlatform == platform.Unknown {
 				return fmt.Errorf("cannot autodetect the platform, and no platform given")
 			}
-			versionDetect, source := detect.FindVersion(platDetect.Discovered, commonOpts.UserPlatformVersion)
+			versionDetect, source, _ := detect.FindVersion(platDetect.Discovered, commonOpts.UserPlatformVersion)
 			commonOpts.DebugLog.Printf("Version detection source: %s", source)
 			opts.clusterVersion = versionDetect.Discovered
 			if opts.clusterVersion == platform.MissingVersion {
@@ -146,13 +146,13 @@ func NewDeploySchedulerPluginCommand(commonOpts *CommonOptions, opts *DeployOpti
 		Short: "deploy the scheduler plugin needed for topology-aware-scheduling",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			la := tlog.NewLogAdapter(commonOpts.Log, commonOpts.DebugLog)
-			platDetect, reason := detect.FindPlatform(commonOpts.UserPlatform)
+			platDetect, reason, _ := detect.FindPlatform(commonOpts.UserPlatform)
 			commonOpts.DebugLog.Printf("platform %s (%s)", platDetect.Discovered, reason)
 			opts.clusterPlatform = platDetect.Discovered
 			if opts.clusterPlatform == platform.Unknown {
 				return fmt.Errorf("cannot autodetect the platform, and no platform given")
 			}
-			versionDetect, source := detect.FindVersion(platDetect.Discovered, commonOpts.UserPlatformVersion)
+			versionDetect, source, _ := detect.FindVersion(platDetect.Discovered, commonOpts.UserPlatformVersion)
 			commonOpts.DebugLog.Printf("Version detection source: %s", source)
 			opts.clusterVersion = versionDetect.Discovered
 			if opts.clusterVersion == platform.MissingVersion {
@@ -176,13 +176,13 @@ func NewDeployTopologyUpdaterCommand(commonOpts *CommonOptions, opts *DeployOpti
 		Short: "deploy the topology updater needed for topology-aware-scheduling",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			la := tlog.NewLogAdapter(commonOpts.Log, commonOpts.DebugLog)
-			platDetect, reason := detect.FindPlatform(commonOpts.UserPlatform)
+			platDetect, reason, _ := detect.FindPlatform(commonOpts.UserPlatform)
 			commonOpts.DebugLog.Printf("platform %s (%s)", platDetect.Discovered, reason)
 			opts.clusterPlatform = platDetect.Discovered
 			if opts.clusterPlatform == platform.Unknown {
 				return fmt.Errorf("cannot autodetect the platform, and no platform given")
 			}
-			versionDetect, source := detect.FindVersion(platDetect.Discovered, commonOpts.UserPlatformVersion)
+			versionDetect, source, _ := detect.FindVersion(platDetect.Discovered, commonOpts.UserPlatformVersion)
 			commonOpts.DebugLog.Printf("Version detection source: %s", source)
 			opts.clusterVersion = versionDetect.Discovered
 			if opts.clusterVersion == platform.MissingVersion {
@@ -207,13 +207,13 @@ func NewRemoveAPICommand(commonOpts *CommonOptions, opts *DeployOptions) *cobra.
 		Short: "remove the APIs needed for topology-aware-scheduling",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			la := tlog.NewLogAdapter(commonOpts.Log, commonOpts.DebugLog)
-			platDetect, reason := detect.FindPlatform(commonOpts.UserPlatform)
+			platDetect, reason, _ := detect.FindPlatform(commonOpts.UserPlatform)
 			commonOpts.DebugLog.Printf("platform %s (%s)", platDetect.Discovered, reason)
 			opts.clusterPlatform = platDetect.Discovered
 			if opts.clusterPlatform == platform.Unknown {
 				return fmt.Errorf("cannot autodetect the platform, and no platform given")
 			}
-			versionDetect, source := detect.FindVersion(platDetect.Discovered, commonOpts.UserPlatformVersion)
+			versionDetect, source, _ := detect.FindVersion(platDetect.Discovered, commonOpts.UserPlatformVersion)
 			commonOpts.DebugLog.Printf("Version detection source: %s", source)
 			opts.clusterVersion = versionDetect.Discovered
 			if opts.clusterVersion == platform.MissingVersion {
@@ -235,13 +235,13 @@ func NewRemoveSchedulerPluginCommand(commonOpts *CommonOptions, opts *DeployOpti
 		Short: "remove the scheduler plugin needed for topology-aware-scheduling",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			la := tlog.NewLogAdapter(commonOpts.Log, commonOpts.DebugLog)
-			platDetect, reason := detect.FindPlatform(commonOpts.UserPlatform)
+			platDetect, reason, _ := detect.FindPlatform(commonOpts.UserPlatform)
 			commonOpts.DebugLog.Printf("platform %s (%s)", platDetect.Discovered, reason)
 			opts.clusterPlatform = platDetect.Discovered
 			if opts.clusterPlatform == platform.Unknown {
 				return fmt.Errorf("cannot autodetect the platform, and no platform given")
 			}
-			versionDetect, source := detect.FindVersion(platDetect.Discovered, commonOpts.UserPlatformVersion)
+			versionDetect, source, _ := detect.FindVersion(platDetect.Discovered, commonOpts.UserPlatformVersion)
 			commonOpts.DebugLog.Printf("Version detection source: %s", source)
 			opts.clusterVersion = versionDetect.Discovered
 			if opts.clusterVersion == platform.MissingVersion {
@@ -265,13 +265,13 @@ func NewRemoveTopologyUpdaterCommand(commonOpts *CommonOptions, opts *DeployOpti
 		Short: "remove the topology updater needed for topology-aware-scheduling",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			la := tlog.NewLogAdapter(commonOpts.Log, commonOpts.DebugLog)
-			platDetect, reason := detect.FindPlatform(commonOpts.UserPlatform)
+			platDetect, reason, _ := detect.FindPlatform(commonOpts.UserPlatform)
 			commonOpts.DebugLog.Printf("platform %s (%s)", platDetect.Discovered, reason)
 			opts.clusterPlatform = platDetect.Discovered
 			if opts.clusterPlatform == platform.Unknown {
 				return fmt.Errorf("cannot autodetect the platform, and no platform given")
 			}
-			versionDetect, source := detect.FindVersion(platDetect.Discovered, commonOpts.UserPlatformVersion)
+			versionDetect, source, _ := detect.FindVersion(platDetect.Discovered, commonOpts.UserPlatformVersion)
 			commonOpts.DebugLog.Printf("Version detection source: %s", source)
 			opts.clusterVersion = versionDetect.Discovered
 			if opts.clusterVersion == platform.MissingVersion {
@@ -292,13 +292,13 @@ func NewRemoveTopologyUpdaterCommand(commonOpts *CommonOptions, opts *DeployOpti
 
 func deployOnCluster(commonOpts *CommonOptions, opts *DeployOptions) error {
 	la := tlog.NewLogAdapter(commonOpts.Log, commonOpts.DebugLog)
-	platDetect, reason := detect.FindPlatform(commonOpts.UserPlatform)
+	platDetect, reason, _ := detect.FindPlatform(commonOpts.UserPlatform)
 	commonOpts.DebugLog.Printf("platform %s (%s)", platDetect.Discovered, reason)
 	opts.clusterPlatform = platDetect.Discovered
 	if opts.clusterPlatform == platform.Unknown {
 		return fmt.Errorf("cannot autodetect the platform, and no platform given")
 	}
-	versionDetect, source := detect.FindVersion(platDetect.Discovered, commonOpts.UserPlatformVersion)
+	versionDetect, source, _ := detect.FindVersion(platDetect.Discovered, commonOpts.UserPlatformVersion)
 	commonOpts.DebugLog.Printf("Version detection source: %s", source)
 	opts.clusterVersion = versionDetect.Discovered
 	if opts.clusterVersion == platform.MissingVersion {

--- a/pkg/commands/detect.go
+++ b/pkg/commands/detect.go
@@ -36,9 +36,9 @@ func NewDetectCommand(commonOpts *CommonOptions) *cobra.Command {
 		Use:   "detect",
 		Short: "detect the cluster platform (kubernetes, openshift...)",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			platKind, reason := detect.FindPlatform(commonOpts.UserPlatform)
+			platKind, reason, _ := detect.FindPlatform(commonOpts.UserPlatform)
 			commonOpts.DebugLog.Printf("platform kind %s (%s)", platKind.Discovered, reason)
-			platVer, reason := detect.FindVersion(platKind.Discovered, commonOpts.UserPlatformVersion)
+			platVer, reason, _ := detect.FindVersion(platKind.Discovered, commonOpts.UserPlatformVersion)
 			commonOpts.DebugLog.Printf("platform version %s (%s)", platVer.Discovered, reason)
 
 			cluster := detect.ClusterInfo{

--- a/pkg/deployer/platform/detect/autoselection.go
+++ b/pkg/deployer/platform/detect/autoselection.go
@@ -43,7 +43,7 @@ const (
 	DetectedFailure     string = "autodetection failed"
 )
 
-func FindPlatform(userSupplied platform.Platform) (PlatformInfo, string) {
+func FindPlatform(userSupplied platform.Platform) (PlatformInfo, string, error) {
 	do := PlatformInfo{
 		AutoDetected: platform.Unknown,
 		UserSupplied: userSupplied,
@@ -52,20 +52,20 @@ func FindPlatform(userSupplied platform.Platform) (PlatformInfo, string) {
 
 	if do.UserSupplied != platform.Unknown {
 		do.Discovered = do.UserSupplied
-		return do, DetectedFromUser
+		return do, DetectedFromUser, nil
 	}
 
 	dp, err := Platform()
 	if err != nil {
-		return do, DetectedFailure
+		return do, DetectedFailure, err
 	}
 
 	do.AutoDetected = dp
 	do.Discovered = do.AutoDetected
-	return do, DetectedFromCluster
+	return do, DetectedFromCluster, nil
 }
 
-func FindVersion(plat platform.Platform, userSupplied platform.Version) (VersionInfo, string) {
+func FindVersion(plat platform.Platform, userSupplied platform.Version) (VersionInfo, string, error) {
 	do := VersionInfo{
 		AutoDetected: platform.MissingVersion,
 		UserSupplied: userSupplied,
@@ -74,15 +74,15 @@ func FindVersion(plat platform.Platform, userSupplied platform.Version) (Version
 
 	if do.UserSupplied != platform.MissingVersion {
 		do.Discovered = do.UserSupplied
-		return do, DetectedFromUser
+		return do, DetectedFromUser, nil
 	}
 
 	dv, err := Version(plat)
 	if err != nil {
-		return do, DetectedFailure
+		return do, DetectedFailure, err
 	}
 
 	do.AutoDetected = dv
 	do.Discovered = do.AutoDetected
-	return do, DetectedFromCluster
+	return do, DetectedFromCluster, nil
 }


### PR DESCRIPTION
When the package autoselects the version, it can try to autodetect
from cluster. This is a desired behaviour, but autodetection
can raise an error, and we should properly bubble the error up.

Signed-off-by: Francesco Romani <fromani@redhat.com>