### PR TITLE
rte:rbac: update rbac permissions

### DIFF
--- a/pkg/manifests/yaml/rte/clusterrole.yaml
+++ b/pkg/manifests/yaml/rte/clusterrole.yaml
@@ -6,3 +6,6 @@ rules:
 - apiGroups: ["topology.node.k8s.io"]
   resources: ["noderesourcetopologies"]
   verbs: ["create", "update", "get", "list"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["watch", "list"]


### PR DESCRIPTION
We want to keep the manifests in sync with RTE.
This is needed due to recent changes introduced at:https://github.com/k8stopologyawareschedwg/resource-topology-exporter/pull/120

Signed-off-by: Talor Itzhak <titzhak@redhat.com>