### PR TITLE
manifests: expose codec functions

### DIFF
--- a/pkg/manifests/codec.go
+++ b/pkg/manifests/codec.go
@@ -17,6 +17,7 @@
 package manifests
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 
@@ -47,7 +48,13 @@ func SerializeObject(obj runtime.Object, out io.Writer) error {
 	return srz.Encode(&r, out)
 }
 
-func deserializeObjectFromData(data []byte) (runtime.Object, error) {
+func SerializeObjectToData(obj runtime.Object) ([]byte, error) {
+	var buf bytes.Buffer
+	err := SerializeObject(obj, &buf)
+	return buf.Bytes(), err
+}
+
+func DeserializeObjectFromData(data []byte) (runtime.Object, error) {
 	decode := scheme.Codecs.UniversalDeserializer().Decode
 	obj, _, err := decode(data, nil, nil)
 	if err != nil {
@@ -61,5 +68,5 @@ func loadObject(path string) (runtime.Object, error) {
 	if err != nil {
 		return nil, err
 	}
-	return deserializeObjectFromData(data)
+	return DeserializeObjectFromData(data)
 }

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -576,7 +576,7 @@ func SecurityContextConstraint(component string) (*securityv1.SecurityContextCon
 }
 
 func KubeSchedulerConfigurationFromData(data []byte) (*kubeschedulerconfigv1beta2.KubeSchedulerConfiguration, error) {
-	obj, err := deserializeObjectFromData(data)
+	obj, err := DeserializeObjectFromData(data)
 	if err != nil {
 		return nil, err
 	}
@@ -589,9 +589,7 @@ func KubeSchedulerConfigurationFromData(data []byte) (*kubeschedulerconfigv1beta
 }
 
 func KubeSchedulerConfigurationToData(sc *kubeschedulerconfigv1beta2.KubeSchedulerConfiguration) ([]byte, error) {
-	var buf bytes.Buffer
-	err := SerializeObject(sc, &buf)
-	return buf.Bytes(), err
+	return SerializeObjectToData(sc)
 }
 
 func validateComponent(component string) error {


### PR DESCRIPTION
Serializing/Deserializing is useful for client applications when deal with scheduler plugin arguments.

Signed-off-by: Francesco Romani <fromani@redhat.com>