### PR TITLE
pkg: deployer: dissolve Helper

### DIFF
--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -130,10 +130,7 @@ func PostSetupOptions(commonOpts *CommonOptions) error {
 		commonOpts.RTEConfigData = string(data)
 		commonOpts.DebugLog.Info("RTE config: read", "bytes", len(commonOpts.RTEConfigData))
 	}
-	if err := validateUpdaterType(commonOpts.UpdaterType); err != nil {
-		return err
-	}
-	return nil
+	return validateUpdaterType(commonOpts.UpdaterType)
 }
 
 func validateUpdaterType(updaterType string) error {

--- a/pkg/deployer/api/api.go
+++ b/pkg/deployer/api/api.go
@@ -19,8 +19,6 @@ package api
 import (
 	"fmt"
 
-	"github.com/go-logr/logr"
-
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer"
@@ -36,50 +34,40 @@ func SetupNamespace(plat platform.Platform) (*corev1.Namespace, string, error) {
 	return nil, "", fmt.Errorf("the API is a cluster scoped resource")
 }
 
-func Deploy(log_ logr.Logger, opts Options) error {
+func Deploy(env *deployer.Environment, opts Options) error {
 	var err error
-	log := log_.WithName("API")
-	log.Info("deploying topology-aware-scheduling API")
+	env = env.WithName("API")
+	env.Log.Info("deploying topology-aware-scheduling API")
 
 	mf, err := apimanifests.GetManifests(opts.Platform)
 	if err != nil {
 		return err
 	}
-	log.V(3).Info("API manifests loaded")
+	env.Log.V(3).Info("API manifests loaded")
 
-	hp, err := deployer.NewHelper("API", log)
-	if err != nil {
+	if err = env.CreateObject(mf.Crd); err != nil {
 		return err
 	}
 
-	if err = hp.CreateObject(mf.Crd); err != nil {
-		return err
-	}
-
-	log.Info("deployed topology-aware-scheduling API")
+	env.Log.Info("deployed topology-aware-scheduling API")
 	return nil
 }
 
-func Remove(log_ logr.Logger, opts Options) error {
+func Remove(env *deployer.Environment, opts Options) error {
 	var err error
-	log := log_.WithName("API")
-	log.Info("removing topology-aware-scheduling API")
+	env = env.WithName("API")
+	env.Log.Info("removing topology-aware-scheduling API")
 
 	mf, err := apimanifests.GetManifests(opts.Platform)
 	if err != nil {
 		return err
 	}
-	log.V(3).Info("API manifests loaded")
+	env.Log.V(3).Info("API manifests loaded")
 
-	hp, err := deployer.NewHelper("API", log)
-	if err != nil {
+	if err = env.DeleteObject(mf.Crd); err != nil {
 		return err
 	}
 
-	if err = hp.DeleteObject(mf.Crd); err != nil {
-		return err
-	}
-
-	log.Info("removed topology-aware-scheduling API!")
+	env.Log.Info("removed topology-aware-scheduling API!")
 	return nil
 }

--- a/pkg/deployer/deployer.go
+++ b/pkg/deployer/deployer.go
@@ -18,17 +18,10 @@ package deployer
 
 import (
 	"context"
-	"regexp"
 
 	"github.com/go-logr/logr"
 
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/k8stopologyawareschedwg/deployer/pkg/clientutil"
 )
 
 type WaitableObject struct {
@@ -36,110 +29,36 @@ type WaitableObject struct {
 	Wait func() error
 }
 
-type Helper struct {
-	cli client.Client
-	log logr.Logger
+type Environment struct {
+	Ctx context.Context
+	Cli client.Client
+	Log logr.Logger
 }
 
-func NewHelper(tag string, log logr.Logger) (*Helper, error) {
-	cli, err := clientutil.New()
-	if err != nil {
-		return nil, err
-	}
-	return NewHelperWithClient(cli, tag, log), nil
-}
-
-func NewHelperWithClient(cli client.Client, tag string, log logr.Logger) *Helper {
-	return &Helper{
-		cli: cli,
-		log: log.WithName(tag),
+func (env *Environment) WithName(name string) *Environment {
+	return &Environment{
+		Ctx: env.Ctx,
+		Cli: env.Cli,
+		Log: env.Log.WithName(name),
 	}
 }
 
-func (hp *Helper) CreateObject(obj client.Object) error {
+func (env Environment) CreateObject(obj client.Object) error {
 	objKind := obj.GetObjectKind().GroupVersionKind().Kind // shortcut
-	if err := hp.cli.Create(context.TODO(), obj); err != nil {
-		hp.log.Info("error creating", "kind", objKind, "name", obj.GetName(), "error", err)
+	if err := env.Cli.Create(env.Ctx, obj); err != nil {
+		env.Log.Info("error creating", "kind", objKind, "name", obj.GetName(), "error", err)
 		return err
 	}
-	hp.log.Info("created", "kind", objKind, "name", obj.GetName())
+	env.Log.Info("created", "kind", objKind, "name", obj.GetName())
 	return nil
 }
 
-func (hp *Helper) DeleteObject(obj client.Object) error {
+func (env Environment) DeleteObject(obj client.Object) error {
 	objKind := obj.GetObjectKind().GroupVersionKind().Kind // shortcut
-	if err := hp.cli.Delete(context.TODO(), obj); err != nil {
-		hp.log.Info("error deleting", "kind", objKind, "name", obj.GetName(), "error", err)
+	if err := env.Cli.Delete(env.Ctx, obj); err != nil {
+		env.Log.Info("error deleting", "kind", objKind, "name", obj.GetName(), "error", err)
 		return err
 	}
-	hp.log.Info("deleted", "kind", objKind, "name", obj.GetName())
+	env.Log.Info("deleted", "kind", objKind, "name", obj.GetName())
 	return nil
-}
-
-func (hp *Helper) GetObject(key client.ObjectKey, obj client.Object) error {
-	return hp.cli.Get(context.TODO(), key, obj)
-}
-
-func (hp *Helper) GetPodsByPattern(namespace, pattern string) ([]*corev1.Pod, error) {
-	var podList corev1.PodList
-	err := hp.cli.List(context.TODO(), &podList)
-	if err != nil {
-		return nil, err
-	}
-	hp.log.Info("found matching pods", "count", len(podList.Items), "namespace", namespace, "pattern", pattern)
-
-	podNameRgx, err := regexp.Compile(pattern)
-	if err != nil {
-		return nil, err
-	}
-
-	ret := []*corev1.Pod{}
-	for _, pod := range podList.Items {
-		if match := podNameRgx.FindString(pod.Name); len(match) != 0 {
-			hp.log.Info("pod matches", "name", pod.Name)
-			ret = append(ret, &pod)
-		}
-	}
-	return ret, nil
-}
-
-func (hp *Helper) GetDaemonSetByName(namespace, name string) (*appsv1.DaemonSet, error) {
-	key := client.ObjectKey{
-		Namespace: namespace,
-		Name:      name,
-	}
-	var ds appsv1.DaemonSet
-	err := hp.GetObject(key, &ds)
-	if err != nil {
-		return nil, err
-	}
-	return &ds, nil
-}
-
-func (hp *Helper) IsDaemonSetRunning(namespace, name string) (bool, error) {
-	log := hp.log.WithValues("namespace", namespace, "name", name)
-	ds, err := hp.GetDaemonSetByName(namespace, name)
-	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			log.Info("daemonset not found - retrying")
-			return false, nil
-		}
-		return false, err
-	}
-	log.Info("daemonset", "desired", ds.Status.DesiredNumberScheduled, "current", ds.Status.CurrentNumberScheduled, "ready", ds.Status.NumberReady)
-	return (ds.Status.DesiredNumberScheduled > 0 && ds.Status.DesiredNumberScheduled == ds.Status.NumberReady), nil
-}
-
-func (hp *Helper) IsDaemonSetGone(namespace, name string) (bool, error) {
-	log := hp.log.WithValues("namespace", namespace, "name", name)
-	ds, err := hp.GetDaemonSetByName(namespace, name)
-	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			log.Info("daemonset not found - gone away!")
-			return true, nil
-		}
-		return true, err
-	}
-	log.Info("daemonset running", "count", ds.Status.CurrentNumberScheduled)
-	return false, nil
 }

--- a/pkg/deployer/updaters/objects.go
+++ b/pkg/deployer/updaters/objects.go
@@ -47,38 +47,38 @@ func GetObjects(opts Options, updaterType, namespace string) ([]client.Object, e
 	return nil, fmt.Errorf("unsupported updater: %q", updaterType)
 }
 
-func getCreatableObjects(opts Options, hp *deployer.Helper, log logr.Logger, updaterType, namespace string) ([]deployer.WaitableObject, error) {
+func getCreatableObjects(opts Options, cli client.Client, log logr.Logger, updaterType, namespace string) ([]deployer.WaitableObject, error) {
 	if updaterType == RTE {
 		mf, err := rtemanifests.GetManifests(opts.Platform, opts.PlatformVersion, namespace)
 		if err != nil {
 			return nil, err
 		}
-		return mf.Render(rteOptionsFrom(opts, namespace)).ToCreatableObjects(hp, log), nil
+		return mf.Render(rteOptionsFrom(opts, namespace)).ToCreatableObjects(cli, log), nil
 	}
 	if updaterType == NFD {
 		mf, err := nfdmanifests.GetManifests(opts.Platform, namespace)
 		if err != nil {
 			return nil, err
 		}
-		return mf.Render(nfdOptionsFrom(opts, namespace)).ToCreatableObjects(hp, log), nil
+		return mf.Render(nfdOptionsFrom(opts, namespace)).ToCreatableObjects(cli, log), nil
 	}
 	return nil, fmt.Errorf("unsupported updater: %q", updaterType)
 }
 
-func getDeletableObjects(opts Options, hp *deployer.Helper, log logr.Logger, updaterType, namespace string) ([]deployer.WaitableObject, error) {
+func getDeletableObjects(opts Options, cli client.Client, log logr.Logger, updaterType, namespace string) ([]deployer.WaitableObject, error) {
 	if updaterType == RTE {
 		mf, err := rtemanifests.GetManifests(opts.Platform, opts.PlatformVersion, namespace)
 		if err != nil {
 			return nil, err
 		}
-		return mf.Render(rteOptionsFrom(opts, namespace)).ToDeletableObjects(hp, log), nil
+		return mf.Render(rteOptionsFrom(opts, namespace)).ToDeletableObjects(cli, log), nil
 	}
 	if updaterType == NFD {
 		mf, err := nfdmanifests.GetManifests(opts.Platform, namespace)
 		if err != nil {
 			return nil, err
 		}
-		return mf.Render(nfdOptionsFrom(opts, namespace)).ToDeletableObjects(hp, log), nil
+		return mf.Render(nfdOptionsFrom(opts, namespace)).ToDeletableObjects(cli, log), nil
 	}
 	return nil, fmt.Errorf("unsupported updater: %q", updaterType)
 }

--- a/pkg/manifests/api/api.go
+++ b/pkg/manifests/api/api.go
@@ -40,13 +40,13 @@ func (mf Manifests) ToObjects() []client.Object {
 	}
 }
 
-func (mf Manifests) ToCreatableObjects(hp *deployer.Helper, log logr.Logger) []deployer.WaitableObject {
+func (mf Manifests) ToCreatableObjects(cli client.Client, log logr.Logger) []deployer.WaitableObject {
 	return []deployer.WaitableObject{
 		{Obj: mf.Crd},
 	}
 }
 
-func (mf Manifests) ToDeletableObjects(hp *deployer.Helper, log logr.Logger) []deployer.WaitableObject {
+func (mf Manifests) ToDeletableObjects(cli client.Client, log logr.Logger) []deployer.WaitableObject {
 	return []deployer.WaitableObject{
 		{Obj: mf.Crd},
 	}

--- a/pkg/manifests/nfd/nfd.go
+++ b/pkg/manifests/nfd/nfd.go
@@ -124,7 +124,7 @@ func (mf Manifests) ToObjects() []client.Object {
 	}
 }
 
-func (mf Manifests) ToCreatableObjects(hp *deployer.Helper, log logr.Logger) []deployer.WaitableObject {
+func (mf Manifests) ToCreatableObjects(cli client.Client, log logr.Logger) []deployer.WaitableObject {
 	return []deployer.WaitableObject{
 		{Obj: mf.CRMaster},
 		{Obj: mf.CRBMaster},
@@ -133,7 +133,7 @@ func (mf Manifests) ToCreatableObjects(hp *deployer.Helper, log logr.Logger) []d
 		{
 			Obj: mf.DPMaster,
 			Wait: func() error {
-				return wait.PodsToBeRunningByRegex(hp, log, mf.DPMaster.Namespace, mf.DPMaster.Name)
+				return wait.PodsToBeRunningByRegex(cli, log, mf.DPMaster.Namespace, mf.DPMaster.Name)
 			},
 		},
 		{Obj: mf.SATopologyUpdater},
@@ -142,13 +142,13 @@ func (mf Manifests) ToCreatableObjects(hp *deployer.Helper, log logr.Logger) []d
 		{
 			Obj: mf.DSTopologyUpdater,
 			Wait: func() error {
-				return wait.PodsToBeRunningByRegex(hp, log, mf.DSTopologyUpdater.Namespace, mf.DSTopologyUpdater.Name)
+				return wait.PodsToBeRunningByRegex(cli, log, mf.DSTopologyUpdater.Namespace, mf.DSTopologyUpdater.Name)
 			},
 		},
 	}
 }
 
-func (mf Manifests) ToDeletableObjects(hp *deployer.Helper, log logr.Logger) []deployer.WaitableObject {
+func (mf Manifests) ToDeletableObjects(cli client.Client, log logr.Logger) []deployer.WaitableObject {
 	return []deployer.WaitableObject{
 		{Obj: mf.CRBTopologyUpdater},
 		{Obj: mf.CRTopologyUpdater},

--- a/pkg/manifests/rte/rte.go
+++ b/pkg/manifests/rte/rte.go
@@ -175,7 +175,7 @@ func (mf Manifests) ToObjects() []client.Object {
 	)
 }
 
-func (mf Manifests) ToCreatableObjects(hp *deployer.Helper, log logr.Logger) []deployer.WaitableObject {
+func (mf Manifests) ToCreatableObjects(cli client.Client, log logr.Logger) []deployer.WaitableObject {
 	var objs []deployer.WaitableObject
 	if mf.ConfigMap != nil {
 		objs = append(objs, deployer.WaitableObject{
@@ -204,16 +204,16 @@ func (mf Manifests) ToCreatableObjects(hp *deployer.Helper, log logr.Logger) []d
 		deployer.WaitableObject{Obj: mf.ServiceAccount},
 		deployer.WaitableObject{
 			Obj:  mf.DaemonSet,
-			Wait: func() error { return wait.DaemonSetToBeRunning(hp, log, mf.DaemonSet.Namespace, mf.DaemonSet.Name) },
+			Wait: func() error { return wait.DaemonSetToBeRunning(cli, log, mf.DaemonSet.Namespace, mf.DaemonSet.Name) },
 		},
 	)
 }
 
-func (mf Manifests) ToDeletableObjects(hp *deployer.Helper, log logr.Logger) []deployer.WaitableObject {
+func (mf Manifests) ToDeletableObjects(cli client.Client, log logr.Logger) []deployer.WaitableObject {
 	objs := []deployer.WaitableObject{
 		{
 			Obj:  mf.DaemonSet,
-			Wait: func() error { return wait.DaemonSetToBeGone(hp, log, mf.DaemonSet.Namespace, mf.DaemonSet.Name) },
+			Wait: func() error { return wait.DaemonSetToBeGone(cli, log, mf.DaemonSet.Namespace, mf.DaemonSet.Name) },
 		},
 		{Obj: mf.Role},
 		{Obj: mf.RoleBinding},

--- a/pkg/manifests/sched/sched.go
+++ b/pkg/manifests/sched/sched.go
@@ -129,7 +129,7 @@ func (mf Manifests) ToObjects() []client.Object {
 	}
 }
 
-func (mf Manifests) ToCreatableObjects(hp *deployer.Helper, log logr.Logger) []deployer.WaitableObject {
+func (mf Manifests) ToCreatableObjects(cli client.Client, log logr.Logger) []deployer.WaitableObject {
 	return []deployer.WaitableObject{
 		{Obj: mf.Crd},
 		{Obj: mf.Namespace},
@@ -141,7 +141,7 @@ func (mf Manifests) ToCreatableObjects(hp *deployer.Helper, log logr.Logger) []d
 		{
 			Obj: mf.DPScheduler,
 			Wait: func() error {
-				return wait.PodsToBeRunningByRegex(hp, log, mf.DPScheduler.Namespace, mf.DPScheduler.Name)
+				return wait.PodsToBeRunningByRegex(cli, log, mf.DPScheduler.Namespace, mf.DPScheduler.Name)
 			},
 		},
 		{Obj: mf.SAController},
@@ -151,17 +151,17 @@ func (mf Manifests) ToCreatableObjects(hp *deployer.Helper, log logr.Logger) []d
 		{
 			Obj: mf.DPController,
 			Wait: func() error {
-				return wait.PodsToBeRunningByRegex(hp, log, mf.DPController.Namespace, mf.DPController.Name)
+				return wait.PodsToBeRunningByRegex(cli, log, mf.DPController.Namespace, mf.DPController.Name)
 			},
 		},
 	}
 }
 
-func (mf Manifests) ToDeletableObjects(hp *deployer.Helper, log logr.Logger) []deployer.WaitableObject {
+func (mf Manifests) ToDeletableObjects(cli client.Client, log logr.Logger) []deployer.WaitableObject {
 	return []deployer.WaitableObject{
 		{
 			Obj:  mf.Namespace,
-			Wait: func() error { return wait.NamespaceToBeGone(hp, log, mf.Namespace.Name) },
+			Wait: func() error { return wait.NamespaceToBeGone(cli, log, mf.Namespace.Name) },
 		},
 		// no need to remove objects created inside the namespace we just removed
 		{Obj: mf.CRBScheduler},


### PR DESCRIPTION
remove the Helper abstraction. Seemed a good idea, turned out to lack focus and adding unnecessary abstraction.
We turn the good bits of Helper into a plain Data-only object we use to pass around the context. Some methods are too shallow and are just inlined; other are copied (and made private) in the one and only calling site.

Closes: #113
Signed-off-by: Francesco Romani <fromani@redhat.com>