### PR TITLE
pkg: clientutil: commands: use env in `nodes`

### DIFF
--- a/pkg/clientutil/nodes/nodes.go
+++ b/pkg/clientutil/nodes/nodes.go
@@ -17,37 +17,34 @@
 package nodes
 
 import (
-	"context"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/k8stopologyawareschedwg/deployer/pkg/clientutil"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer"
 )
 
-func GetWorkers() ([]corev1.Node, error) {
-	return GetByRole(clientutil.RoleWorker)
+func GetWorkers(env *deployer.Environment) ([]corev1.Node, error) {
+	return GetByRole(env, clientutil.RoleWorker)
 }
 
 // GetByRole returns all nodes with the specified role
-func GetByRole(role string) ([]corev1.Node, error) {
+func GetByRole(env *deployer.Environment, role string) ([]corev1.Node, error) {
 	selector, err := labels.Parse(fmt.Sprintf("%s/%s=", clientutil.LabelRole, role))
 	if err != nil {
 		return nil, err
 	}
-	return GetBySelector(selector)
+	return GetBySelector(env, selector)
 }
 
 // GetBySelector returns all nodes with the specified selector
-func GetBySelector(selector labels.Selector) ([]corev1.Node, error) {
-	cli, err := clientutil.New()
-	if err != nil {
-		return nil, err
-	}
+func GetBySelector(env *deployer.Environment, selector labels.Selector) ([]corev1.Node, error) {
 	nodes := &corev1.NodeList{}
-	if err := cli.List(context.TODO(), nodes, &client.ListOptions{LabelSelector: selector}); err != nil {
+	if err := env.Cli.List(env.Ctx, nodes, &client.ListOptions{LabelSelector: selector}); err != nil {
 		return nil, err
 	}
 	return nodes.Items, nil

--- a/pkg/commands/deploy.go
+++ b/pkg/commands/deploy.go
@@ -17,13 +17,10 @@
 package commands
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
 
-	"github.com/k8stopologyawareschedwg/deployer/pkg/clientutil"
-	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/api"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform/detect"
@@ -359,16 +356,4 @@ func deployOnCluster(commonOpts *CommonOptions, opts *DeployOptions) error {
 		return err
 	}
 	return nil
-}
-
-func environFromOpts(commonOpts *CommonOptions) (*deployer.Environment, error) {
-	cli, err := clientutil.New()
-	if err != nil {
-		return nil, err
-	}
-	return &deployer.Environment{
-		Ctx: context.TODO(),
-		Cli: cli,
-		Log: commonOpts.Log,
-	}, nil
 }

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -17,6 +17,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -27,6 +28,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	"github.com/k8stopologyawareschedwg/deployer/pkg/clientutil"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/updaters"
 )
@@ -138,4 +141,16 @@ func validateUpdaterType(updaterType string) error {
 		return fmt.Errorf("%q is invalid updater type", updaterType)
 	}
 	return nil
+}
+
+func environFromOpts(commonOpts *CommonOptions) (*deployer.Environment, error) {
+	cli, err := clientutil.New()
+	if err != nil {
+		return nil, err
+	}
+	return &deployer.Environment{
+		Ctx: context.TODO(),
+		Cli: cli,
+		Log: commonOpts.Log,
+	}, nil
 }

--- a/pkg/commands/validate.go
+++ b/pkg/commands/validate.go
@@ -76,12 +76,17 @@ func validateCluster(cmd *cobra.Command, commonOpts *CommonOptions, opts *valida
 	// TODO
 	validatePostSetupOptions(opts)
 
-	vd, err := validator.NewValidator(commonOpts.DebugLog)
+	env, err := environFromOpts(commonOpts)
 	if err != nil {
 		return err
 	}
 
-	nodeList, err := nodes.GetWorkers()
+	vd, err := validator.NewValidator(env.Log)
+	if err != nil {
+		return err
+	}
+
+	nodeList, err := nodes.GetWorkers(env)
 	if err != nil {
 		return err
 	}
@@ -90,7 +95,7 @@ func validateCluster(cmd *cobra.Command, commonOpts *CommonOptions, opts *valida
 		return err
 	}
 
-	printValidationResults(vd.Results(), commonOpts.Log, opts.outputMode)
+	printValidationResults(vd.Results(), env.Log, opts.outputMode)
 	return nil
 }
 

--- a/test/e2e/positive.go
+++ b/test/e2e/positive.go
@@ -40,6 +40,7 @@ import (
 
 	"github.com/k8stopologyawareschedwg/deployer/pkg/clientutil"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/clientutil/nodes"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform/detect"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/updaters"
@@ -233,7 +234,7 @@ var _ = ginkgo.Describe("[PositiveFlow] Deployer execution", func() {
 				tc, err := clientutil.NewTopologyClient()
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-				workers, err := nodes.GetWorkers()
+				workers, err := nodes.GetWorkers(NullEnv())
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 				for _, node := range workers {
 					ginkgo.By(fmt.Sprintf("checking node resource topology for %q", node.Name))
@@ -329,7 +330,7 @@ var _ = ginkgo.Describe("[PositiveFlow] Deployer execution", func() {
 				tc, err := clientutil.NewTopologyClient()
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-				workers, err := nodes.GetWorkers()
+				workers, err := nodes.GetWorkers(NullEnv())
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 				for _, node := range workers {
 					ginkgo.By(fmt.Sprintf("checking node resource topology for %q", node.Name))
@@ -517,4 +518,15 @@ func runCmdline(cmdline []string, errMsg string) error {
 		return fmt.Errorf("%s: %v", errMsg, err)
 	}
 	return nil
+}
+
+func NullEnv() *deployer.Environment {
+	cli, err := clientutil.New()
+	gomega.ExpectWithOffset(1, err).ToNot(gomega.HaveOccurred())
+	env := deployer.Environment{
+		Ctx: context.TODO(),
+		Cli: cli,
+		Log: logr.Discard(),
+	}
+	return &env
 }


### PR DESCRIPTION
Aiming to maximize the reuse of clients, we now require a `deployer.Environment` in the `nodes` subpkg.
This decision is not straightforward, as we have now a kinda clumsy dependency between `deployer` and `clientutil/nodes`. Since `nodes` is a subpkg, the pros seems to outweight the cons, but this decision can be revisited in the future.

Surely, one way or another, `clientutil/nodes` should reuse context, logger and client (= the Env, in some shape or form).

Signed-off-by: Francesco Romani <fromani@redhat.com>