### PR TITLE
images: bump RTE to v0.9.0

### DIFF
--- a/pkg/images/consts.go
+++ b/pkg/images/consts.go
@@ -19,13 +19,13 @@ package images
 const (
 	SchedulerPluginSchedulerDefaultImageTag  = "registry.k8s.io/scheduler-plugins/kube-scheduler:v0.24.9"
 	SchedulerPluginControllerDefaultImageTag = "registry.k8s.io/scheduler-plugins/controller:v0.24.9"
-	ResourceTopologyExporterDefaultImageTag  = "quay.io/k8stopologyawareschedwg/resource-topology-exporter:v0.6.0"
+	ResourceTopologyExporterDefaultImageTag  = "quay.io/k8stopologyawareschedwg/resource-topology-exporter:v0.9.0"
 	NodeFeatureDiscoveryDefaultImageTag      = "gcr.io/k8s-staging-nfd/node-feature-discovery:v0.10.1"
 )
 
 const (
 	SchedulerPluginSchedulerDefaultImageSHA  = "registry.k8s.io/scheduler-plugins/kube-scheduler@sha256:7e5681d6ee55da2a371111401fafd1ba371df83c4f1da088a0a7b20a2951eb72"
 	SchedulerPluginControllerDefaultImageSHA = "registry.k8s.io/scheduler-plugins/controller@sha256:28ade406054565a06a7585acd839c420e1a0b8969f5bbe81ca7f0d97a4a483f3"
-	ResourceTopologyExporterDefaultImageSHA  = "quay.io/k8stopologyawareschedwg/resource-topology-exporter@sha256:c4721e940250ef3a31600e70d4c933551492b22ed54c9593ad2a246da976d6f1"
+	ResourceTopologyExporterDefaultImageSHA  = "quay.io/k8stopologyawareschedwg/resource-topology-exporter@sha256:fe556f871ceec7497e6216b08719d3aab1643ee465b78590e36e0357a7ce07d3"
 	NodeFeatureDiscoveryDefaultImageSHA      = "gcr.io/k8s-staging-nfd/node-feature-discovery@sha256:4aebf17c8b72ee91cb468a6f21dd9f0312c1fcfdf8c86341f7aee0ec2d5991d7"
 )


### PR DESCRIPTION
trivial image bump, no API changes are expected.

Signed-off-by: Francesco Romani <fromani@redhat.com>