### PR TITLE
release flow: simplify and compress

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,7 @@ jobs:
       run: |
         cp _out/deployer _out/deployer-${{ env.RELEASE_VERSION }}-linux-amd64
         cp _out/deployer-manifests-allinone.yaml _out/deployer-${{ env.RELEASE_VERSION }}-manifests-allinone.yaml
+        gzip _out/deployer-${{ env.RELEASE_VERSION }}-linux-amd64
 
     - name: compute signature
       run: |
@@ -104,5 +105,5 @@ jobs:
     - name: create release
       uses: ncipollo/release-action@v1
       with:
-        artifacts: "SHA256SUMS,deployer-v*-linux-amd64,deployer-v*.yaml"
+        artifacts: "SHA256SUMS,deployer-v*-linux-amd64.gz,deployer-v*.yaml"
         token: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ defaults:
     shell: bash
 
 jobs:
-  release-build:
+  release:
     runs-on: ubuntu-20.04
     steps:
     - name: checkout sources
@@ -68,11 +68,11 @@ jobs:
       run: |
         hack/make-checksum.sh ${{ env.RELEASE_VERSION }}
 
-    - name: upload build artifacts
-      uses: actions/upload-artifact@v2
+    - name: create release
+      uses: ncipollo/release-action@v1
       with:
-        name: build-artifacts
-        path: _out/*
+        artifacts: "SHA256SUMS,deployer-v*-linux-amd64.gz,deployer-v*.yaml"
+        token: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
 
     - name: export kind logs
       if: ${{ failure() }}
@@ -85,25 +85,3 @@ jobs:
       with:
         name: kind-logs
         path: /tmp/kind-logs
-
-  release:
-    needs: [release-build]
-    runs-on: ubuntu-20.04
-    steps:
-    - name: checkout sources
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-
-    # todo: create changelog and/or release body
-
-    - name: download again the build artifacts
-      uses: actions/download-artifact@v2
-      with:
-        name: build-artifacts
-
-    - name: create release
-      uses: ncipollo/release-action@v1
-      with:
-        artifacts: "SHA256SUMS,deployer-v*-linux-amd64.gz,deployer-v*.yaml"
-        token: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token

--- a/hack/make-checksum.sh
+++ b/hack/make-checksum.sh
@@ -4,7 +4,7 @@ set -eu
 
 VERSION="${1}"
 FILES="
-deployer-${VERSION}-linux-amd64
+deployer-${VERSION}-linux-amd64.gz
 deployer-${VERSION}-manifests-allinone.yaml
 "
 


### PR DESCRIPTION
simplification of the release flow. This includes compressing the steps - we don't need multi stage builds but also compressing the output binary, which saves roughly 50% of the overall artifacts size.