### PR TITLE
context: add and use explicit context in libraries

### DIFF
--- a/pkg/commands/deploy.go
+++ b/pkg/commands/deploy.go
@@ -17,6 +17,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -62,12 +63,14 @@ func NewRemoveCommand(commonOpts *CommonOptions) *cobra.Command {
 				return err
 			}
 
-			platDetect, reason, _ := detect.FindPlatform(commonOpts.UserPlatform)
+			ctx := context.Background()
+
+			platDetect, reason, _ := detect.FindPlatform(ctx, commonOpts.UserPlatform)
 			opts.clusterPlatform = platDetect.Discovered
 			if opts.clusterPlatform == platform.Unknown {
 				return fmt.Errorf("cannot autodetect the platform, and no platform given")
 			}
-			versionDetect, source, _ := detect.FindVersion(platDetect.Discovered, commonOpts.UserPlatformVersion)
+			versionDetect, source, _ := detect.FindVersion(ctx, platDetect.Discovered, commonOpts.UserPlatformVersion)
 			opts.clusterVersion = versionDetect.Discovered
 			if opts.clusterVersion == platform.MissingVersion {
 				return fmt.Errorf("cannot autodetect the platform version, and no version given")
@@ -124,12 +127,14 @@ func NewDeployAPICommand(commonOpts *CommonOptions, opts *DeployOptions) *cobra.
 				return err
 			}
 
-			platDetect, reason, _ := detect.FindPlatform(commonOpts.UserPlatform)
+			ctx := context.Background()
+
+			platDetect, reason, _ := detect.FindPlatform(ctx, commonOpts.UserPlatform)
 			opts.clusterPlatform = platDetect.Discovered
 			if opts.clusterPlatform == platform.Unknown {
 				return fmt.Errorf("cannot autodetect the platform, and no platform given")
 			}
-			versionDetect, source, _ := detect.FindVersion(platDetect.Discovered, commonOpts.UserPlatformVersion)
+			versionDetect, source, _ := detect.FindVersion(ctx, platDetect.Discovered, commonOpts.UserPlatformVersion)
 			opts.clusterVersion = versionDetect.Discovered
 			if opts.clusterVersion == platform.MissingVersion {
 				return fmt.Errorf("cannot autodetect the platform version, and no version given")
@@ -156,12 +161,14 @@ func NewDeploySchedulerPluginCommand(commonOpts *CommonOptions, opts *DeployOpti
 				return err
 			}
 
-			platDetect, reason, _ := detect.FindPlatform(commonOpts.UserPlatform)
+			ctx := context.Background()
+
+			platDetect, reason, _ := detect.FindPlatform(ctx, commonOpts.UserPlatform)
 			opts.clusterPlatform = platDetect.Discovered
 			if opts.clusterPlatform == platform.Unknown {
 				return fmt.Errorf("cannot autodetect the platform, and no platform given")
 			}
-			versionDetect, source, _ := detect.FindVersion(platDetect.Discovered, commonOpts.UserPlatformVersion)
+			versionDetect, source, _ := detect.FindVersion(ctx, platDetect.Discovered, commonOpts.UserPlatformVersion)
 			opts.clusterVersion = versionDetect.Discovered
 			if opts.clusterVersion == platform.MissingVersion {
 				return fmt.Errorf("cannot autodetect the platform version, and no version given")
@@ -191,12 +198,14 @@ func NewDeployTopologyUpdaterCommand(commonOpts *CommonOptions, opts *DeployOpti
 				return err
 			}
 
-			platDetect, reason, _ := detect.FindPlatform(commonOpts.UserPlatform)
+			ctx := context.Background()
+
+			platDetect, reason, _ := detect.FindPlatform(ctx, commonOpts.UserPlatform)
 			opts.clusterPlatform = platDetect.Discovered
 			if opts.clusterPlatform == platform.Unknown {
 				return fmt.Errorf("cannot autodetect the platform, and no platform given")
 			}
-			versionDetect, source, _ := detect.FindVersion(platDetect.Discovered, commonOpts.UserPlatformVersion)
+			versionDetect, source, _ := detect.FindVersion(ctx, platDetect.Discovered, commonOpts.UserPlatformVersion)
 			opts.clusterVersion = versionDetect.Discovered
 			if opts.clusterVersion == platform.MissingVersion {
 				return fmt.Errorf("cannot autodetect the platform version, and no version given")
@@ -226,12 +235,14 @@ func NewRemoveAPICommand(commonOpts *CommonOptions, opts *DeployOptions) *cobra.
 				return err
 			}
 
-			platDetect, reason, _ := detect.FindPlatform(commonOpts.UserPlatform)
+			ctx := context.Background()
+
+			platDetect, reason, _ := detect.FindPlatform(ctx, commonOpts.UserPlatform)
 			opts.clusterPlatform = platDetect.Discovered
 			if opts.clusterPlatform == platform.Unknown {
 				return fmt.Errorf("cannot autodetect the platform, and no platform given")
 			}
-			versionDetect, source, _ := detect.FindVersion(platDetect.Discovered, commonOpts.UserPlatformVersion)
+			versionDetect, source, _ := detect.FindVersion(ctx, platDetect.Discovered, commonOpts.UserPlatformVersion)
 			opts.clusterVersion = versionDetect.Discovered
 			if opts.clusterVersion == platform.MissingVersion {
 				return fmt.Errorf("cannot autodetect the platform version, and no version given")
@@ -258,12 +269,14 @@ func NewRemoveSchedulerPluginCommand(commonOpts *CommonOptions, opts *DeployOpti
 				return err
 			}
 
-			platDetect, reason, _ := detect.FindPlatform(commonOpts.UserPlatform)
+			ctx := context.Background()
+
+			platDetect, reason, _ := detect.FindPlatform(ctx, commonOpts.UserPlatform)
 			opts.clusterPlatform = platDetect.Discovered
 			if opts.clusterPlatform == platform.Unknown {
 				return fmt.Errorf("cannot autodetect the platform, and no platform given")
 			}
-			versionDetect, source, _ := detect.FindVersion(platDetect.Discovered, commonOpts.UserPlatformVersion)
+			versionDetect, source, _ := detect.FindVersion(ctx, platDetect.Discovered, commonOpts.UserPlatformVersion)
 			opts.clusterVersion = versionDetect.Discovered
 			if opts.clusterVersion == platform.MissingVersion {
 				return fmt.Errorf("cannot autodetect the platform version, and no version given")
@@ -293,12 +306,14 @@ func NewRemoveTopologyUpdaterCommand(commonOpts *CommonOptions, opts *DeployOpti
 				return err
 			}
 
-			platDetect, reason, _ := detect.FindPlatform(commonOpts.UserPlatform)
+			ctx := context.Background()
+
+			platDetect, reason, _ := detect.FindPlatform(ctx, commonOpts.UserPlatform)
 			opts.clusterPlatform = platDetect.Discovered
 			if opts.clusterPlatform == platform.Unknown {
 				return fmt.Errorf("cannot autodetect the platform, and no platform given")
 			}
-			versionDetect, source, _ := detect.FindVersion(platDetect.Discovered, commonOpts.UserPlatformVersion)
+			versionDetect, source, _ := detect.FindVersion(ctx, platDetect.Discovered, commonOpts.UserPlatformVersion)
 			opts.clusterVersion = versionDetect.Discovered
 			if opts.clusterVersion == platform.MissingVersion {
 				return fmt.Errorf("cannot autodetect the platform version, and no version given")
@@ -324,12 +339,14 @@ func deployOnCluster(commonOpts *CommonOptions, opts *DeployOptions) error {
 		return err
 	}
 
-	platDetect, reason, _ := detect.FindPlatform(commonOpts.UserPlatform)
+	ctx := context.Background()
+
+	platDetect, reason, _ := detect.FindPlatform(ctx, commonOpts.UserPlatform)
 	opts.clusterPlatform = platDetect.Discovered
 	if opts.clusterPlatform == platform.Unknown {
 		return fmt.Errorf("cannot autodetect the platform, and no platform given")
 	}
-	versionDetect, source, _ := detect.FindVersion(platDetect.Discovered, commonOpts.UserPlatformVersion)
+	versionDetect, source, _ := detect.FindVersion(ctx, platDetect.Discovered, commonOpts.UserPlatformVersion)
 	opts.clusterVersion = versionDetect.Discovered
 	if opts.clusterVersion == platform.MissingVersion {
 		return fmt.Errorf("cannot autodetect the platform version, and no version given")

--- a/pkg/commands/detect.go
+++ b/pkg/commands/detect.go
@@ -17,6 +17,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -34,8 +35,10 @@ func NewDetectCommand(commonOpts *CommonOptions) *cobra.Command {
 		Use:   "detect",
 		Short: "detect the cluster platform (kubernetes, openshift...)",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			platKind, kindReason, _ := detect.FindPlatform(commonOpts.UserPlatform)
-			platVer, verReason, _ := detect.FindVersion(platKind.Discovered, commonOpts.UserPlatformVersion)
+			ctx := context.Background()
+
+			platKind, kindReason, _ := detect.FindPlatform(ctx, commonOpts.UserPlatform)
+			platVer, verReason, _ := detect.FindVersion(ctx, platKind.Discovered, commonOpts.UserPlatformVersion)
 
 			commonOpts.DebugLog.Info("detection", "platform", platKind, "reason", kindReason, "version", platVer, "source", verReason)
 

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -160,7 +160,7 @@ func environFromOpts(commonOpts *CommonOptions) (*deployer.Environment, error) {
 		return nil, err
 	}
 	return &deployer.Environment{
-		Ctx: context.TODO(),
+		Ctx: context.Background(),
 		Cli: cli,
 		Log: commonOpts.Log,
 	}, nil

--- a/pkg/deployer/deployer.go
+++ b/pkg/deployer/deployer.go
@@ -26,7 +26,7 @@ import (
 
 type WaitableObject struct {
 	Obj  client.Object
-	Wait func() error
+	Wait func(ctx context.Context) error
 }
 
 type Environment struct {

--- a/pkg/deployer/platform/detect/autoselection.go
+++ b/pkg/deployer/platform/detect/autoselection.go
@@ -17,6 +17,7 @@
 package detect
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -58,7 +59,7 @@ const (
 	DetectedFailure     string = "autodetection failed"
 )
 
-func FindPlatform(userSupplied platform.Platform) (PlatformInfo, string, error) {
+func FindPlatform(ctx context.Context, userSupplied platform.Platform) (PlatformInfo, string, error) {
 	do := PlatformInfo{
 		AutoDetected: platform.Unknown,
 		UserSupplied: userSupplied,
@@ -70,7 +71,7 @@ func FindPlatform(userSupplied platform.Platform) (PlatformInfo, string, error) 
 		return do, DetectedFromUser, nil
 	}
 
-	dp, err := Platform()
+	dp, err := Platform(ctx)
 	if err != nil {
 		return do, DetectedFailure, err
 	}
@@ -80,7 +81,7 @@ func FindPlatform(userSupplied platform.Platform) (PlatformInfo, string, error) 
 	return do, DetectedFromCluster, nil
 }
 
-func FindVersion(plat platform.Platform, userSupplied platform.Version) (VersionInfo, string, error) {
+func FindVersion(ctx context.Context, plat platform.Platform, userSupplied platform.Version) (VersionInfo, string, error) {
 	do := VersionInfo{
 		AutoDetected: platform.MissingVersion,
 		UserSupplied: userSupplied,
@@ -92,7 +93,7 @@ func FindVersion(plat platform.Platform, userSupplied platform.Version) (Version
 		return do, DetectedFromUser, nil
 	}
 
-	dv, err := Version(plat)
+	dv, err := Version(ctx, plat)
 	if err != nil {
 		return do, DetectedFailure, err
 	}

--- a/pkg/deployer/sched/sched.go
+++ b/pkg/deployer/sched/sched.go
@@ -62,7 +62,7 @@ func Deploy(env *deployer.Environment, opts Options) error {
 			return err
 		}
 		if opts.WaitCompletion && wo.Wait != nil {
-			err = wo.Wait()
+			err = wo.Wait(env.Ctx)
 			if err != nil {
 				return err
 			}
@@ -102,7 +102,7 @@ func Remove(env *deployer.Environment, opts Options) error {
 			continue
 		}
 
-		err = wo.Wait()
+		err = wo.Wait(env.Ctx)
 		if err != nil {
 			env.Log.Info("failed to wait for removal", "error", err)
 		}

--- a/pkg/deployer/updaters/updaters.go
+++ b/pkg/deployer/updaters/updaters.go
@@ -17,6 +17,7 @@
 package updaters
 
 import (
+	"context"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -63,7 +64,7 @@ func Deploy(env *deployer.Environment, updaterType string, opts Options) error {
 			return err
 		}
 		if opts.WaitCompletion && wo.Wait != nil {
-			err = wo.Wait()
+			err = wo.Wait(env.Ctx)
 			if err != nil {
 				return err
 			}
@@ -94,7 +95,7 @@ func Remove(env *deployer.Environment, updaterType string, opts Options) error {
 
 	objs = append(objs, deployer.WaitableObject{
 		Obj:  ns,
-		Wait: func() error { return wait.ForNamespaceDeleted(env.Cli, env.Log, ns.Name) },
+		Wait: func(ctx context.Context) error { return wait.ForNamespaceDeleted(ctx, env.Cli, env.Log, ns.Name) },
 	})
 	for _, wo := range objs {
 		err = env.DeleteObject(wo.Obj)
@@ -106,7 +107,7 @@ func Remove(env *deployer.Environment, updaterType string, opts Options) error {
 			continue
 		}
 
-		err = wo.Wait()
+		err = wo.Wait(env.Ctx)
 		if err != nil {
 			env.Log.Info("failed to wait for removal", "error", err)
 		}

--- a/pkg/deployer/wait/daemonset.go
+++ b/pkg/deployer/wait/daemonset.go
@@ -27,10 +27,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func ForDaemonSetReadyByKey(cli client.Client, logger logr.Logger, key ObjectKey, pollInterval, pollTimeout time.Duration) (*appsv1.DaemonSet, error) {
+func ForDaemonSetReadyByKey(ctx context.Context, cli client.Client, logger logr.Logger, key ObjectKey, pollInterval, pollTimeout time.Duration) (*appsv1.DaemonSet, error) {
 	updatedDs := &appsv1.DaemonSet{}
 	err := k8swait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
-		err := cli.Get(context.TODO(), key.AsKey(), updatedDs)
+		err := cli.Get(ctx, key.AsKey(), updatedDs)
 		if err != nil {
 			logger.Info("failed to get the daemonset", "key", key.String(), "error", err)
 			return false, err
@@ -51,8 +51,8 @@ func ForDaemonSetReadyByKey(cli client.Client, logger logr.Logger, key ObjectKey
 	return updatedDs, err
 }
 
-func ForDaemonSetReady(cli client.Client, logger logr.Logger, ds *appsv1.DaemonSet, pollInterval, pollTimeout time.Duration) (*appsv1.DaemonSet, error) {
-	return ForDaemonSetReadyByKey(cli, logger, ObjectKeyFromObject(ds), pollInterval, pollTimeout)
+func ForDaemonSetReady(ctx context.Context, cli client.Client, logger logr.Logger, ds *appsv1.DaemonSet, pollInterval, pollTimeout time.Duration) (*appsv1.DaemonSet, error) {
+	return ForDaemonSetReadyByKey(ctx, cli, logger, ObjectKeyFromObject(ds), pollInterval, pollTimeout)
 }
 
 func AreDaemonSetPodsReady(newStatus *appsv1.DaemonSetStatus) bool {
@@ -60,11 +60,11 @@ func AreDaemonSetPodsReady(newStatus *appsv1.DaemonSetStatus) bool {
 		newStatus.DesiredNumberScheduled == newStatus.NumberReady
 }
 
-func ForDaemonSetDeleted(cli client.Client, logger logr.Logger, namespace, name string, pollTimeout time.Duration) error {
+func ForDaemonSetDeleted(ctx context.Context, cli client.Client, logger logr.Logger, namespace, name string, pollTimeout time.Duration) error {
 	return k8swait.PollImmediate(time.Second, pollTimeout, func() (bool, error) {
 		obj := appsv1.DaemonSet{}
 		key := ObjectKey{Name: name, Namespace: namespace}
-		err := cli.Get(context.TODO(), key.AsKey(), &obj)
+		err := cli.Get(ctx, key.AsKey(), &obj)
 		return deletionStatusFromError(logger, "DaemonSet", key, err)
 	})
 }

--- a/pkg/deployer/wait/wait.go
+++ b/pkg/deployer/wait/wait.go
@@ -58,13 +58,13 @@ func (ok ObjectKey) String() string {
 	return fmt.Sprintf("%s/%s", ok.Namespace, ok.Name)
 }
 
-func ForNamespaceDeleted(cli client.Client, log logr.Logger, namespace string) error {
+func ForNamespaceDeleted(ctx context.Context, cli client.Client, log logr.Logger, namespace string) error {
 	log = log.WithValues("namespace", namespace)
 	log.Info("wait for the namespace to be gone")
 	return k8swait.PollImmediate(1*time.Second, 3*time.Minute, func() (bool, error) {
 		nsKey := ObjectKey{Name: namespace}
 		ns := corev1.Namespace{} // unused
-		err := cli.Get(context.TODO(), nsKey.AsKey(), &ns)
+		err := cli.Get(ctx, nsKey.AsKey(), &ns)
 		return deletionStatusFromError(log, "Namespace", nsKey, err)
 	})
 }

--- a/pkg/manifests/nfd/nfd.go
+++ b/pkg/manifests/nfd/nfd.go
@@ -17,6 +17,8 @@
 package nfd
 
 import (
+	"context"
+
 	"github.com/go-logr/logr"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -99,8 +101,8 @@ func (mf Manifests) ToCreatableObjects(cli client.Client, log logr.Logger) []dep
 		{Obj: mf.CRBTopologyUpdater},
 		{
 			Obj: mf.DSTopologyUpdater,
-			Wait: func() error {
-				_, err := wait.ForDaemonSetReady(cli, log, mf.DSTopologyUpdater, wait.DefaultPollInterval, wait.DefaultPollTimeout)
+			Wait: func(ctx context.Context) error {
+				_, err := wait.ForDaemonSetReady(ctx, cli, log, mf.DSTopologyUpdater, wait.DefaultPollInterval, wait.DefaultPollTimeout)
 				return err
 			},
 		},

--- a/pkg/manifests/rte/rte.go
+++ b/pkg/manifests/rte/rte.go
@@ -17,6 +17,8 @@
 package rte
 
 import (
+	"context"
+
 	"github.com/go-logr/logr"
 
 	securityv1 "github.com/openshift/api/security/v1"
@@ -209,8 +211,8 @@ func (mf Manifests) ToCreatableObjects(cli client.Client, log logr.Logger) []dep
 		deployer.WaitableObject{Obj: mf.ServiceAccount},
 		deployer.WaitableObject{
 			Obj: mf.DaemonSet,
-			Wait: func() error {
-				_, err := wait.ForDaemonSetReadyByKey(cli, log, key, wait.DefaultPollInterval, wait.DefaultPollTimeout)
+			Wait: func(ctx context.Context) error {
+				_, err := wait.ForDaemonSetReadyByKey(ctx, cli, log, key, wait.DefaultPollInterval, wait.DefaultPollTimeout)
 				return err
 			},
 		},
@@ -221,8 +223,8 @@ func (mf Manifests) ToDeletableObjects(cli client.Client, log logr.Logger) []dep
 	objs := []deployer.WaitableObject{
 		{
 			Obj: mf.DaemonSet,
-			Wait: func() error {
-				return wait.ForDaemonSetDeleted(cli, log, mf.DaemonSet.Namespace, mf.DaemonSet.Name, wait.DefaultPollTimeout)
+			Wait: func(ctx context.Context) error {
+				return wait.ForDaemonSetDeleted(ctx, cli, log, mf.DaemonSet.Namespace, mf.DaemonSet.Name, wait.DefaultPollTimeout)
 			},
 		},
 		{Obj: mf.Role},

--- a/pkg/manifests/sched/sched.go
+++ b/pkg/manifests/sched/sched.go
@@ -17,6 +17,7 @@
 package sched
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -150,8 +151,8 @@ func (mf Manifests) ToCreatableObjects(cli client.Client, log logr.Logger) []dep
 		{Obj: mf.ConfigMap},
 		{
 			Obj: mf.DPScheduler,
-			Wait: func() error {
-				_, err := wait.ForDeploymentComplete(cli, log, mf.DPScheduler, wait.DefaultPollInterval, wait.DefaultPollTimeout)
+			Wait: func(ctx context.Context) error {
+				_, err := wait.ForDeploymentComplete(ctx, cli, log, mf.DPScheduler, wait.DefaultPollInterval, wait.DefaultPollTimeout)
 				return err
 			},
 		},
@@ -161,8 +162,8 @@ func (mf Manifests) ToCreatableObjects(cli client.Client, log logr.Logger) []dep
 		{Obj: mf.RBController},
 		{
 			Obj: mf.DPController,
-			Wait: func() error {
-				_, err := wait.ForDeploymentComplete(cli, log, mf.DPController, wait.DefaultPollInterval, wait.DefaultPollTimeout)
+			Wait: func(ctx context.Context) error {
+				_, err := wait.ForDeploymentComplete(ctx, cli, log, mf.DPController, wait.DefaultPollInterval, wait.DefaultPollTimeout)
 				return err
 			},
 		},
@@ -173,7 +174,7 @@ func (mf Manifests) ToDeletableObjects(cli client.Client, log logr.Logger) []dep
 	return []deployer.WaitableObject{
 		{
 			Obj:  mf.Namespace,
-			Wait: func() error { return wait.ForNamespaceDeleted(cli, log, mf.Namespace.Name) },
+			Wait: func(ctx context.Context) error { return wait.ForNamespaceDeleted(ctx, cli, log, mf.Namespace.Name) },
 		},
 		// no need to remove objects created inside the namespace we just removed
 		{Obj: mf.CRBScheduler},

--- a/test/e2e/positive.go
+++ b/test/e2e/positive.go
@@ -450,6 +450,8 @@ var _ = ginkgo.Describe("[PositiveFlow] Deployer partial execution", func() {
 			cli, err := clientutil.New()
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
+			ctx := context.Background()
+
 			var wg sync.WaitGroup
 			for _, dp := range []*appsv1.Deployment{
 				mfs.DPScheduler,
@@ -459,7 +461,7 @@ var _ = ginkgo.Describe("[PositiveFlow] Deployer partial execution", func() {
 				go func(dp *appsv1.Deployment) {
 					defer ginkgo.GinkgoRecover()
 					defer wg.Done()
-					_, err = wait.ForDeploymentComplete(cli, logr.Discard(), dp, 10*time.Second, 3*time.Minute)
+					_, err = wait.ForDeploymentComplete(ctx, cli, logr.Discard(), dp, 10*time.Second, 3*time.Minute)
 					gomega.Expect(err).ToNot(gomega.HaveOccurred())
 				}(dp)
 			}


### PR DESCRIPTION
Up until now, the project libraries hardcoded `context.TODO()` instead of requiring a context from the caller.
This is a bad practice and makes impossible to cancel the APIs, even when the underlyingl libraries allowed to in turn accepting a context.

Fix the API to accept contexts, and pass them through as needed.