### PR TITLE
enable pods fingerprint consumption

### DIFF
--- a/pkg/commands/deploy.go
+++ b/pkg/commands/deploy.go
@@ -78,11 +78,12 @@ func NewRemoveCommand(commonOpts *CommonOptions) *cobra.Command {
 			commonOpts.DebugLog.Info("detection", "platform", opts.clusterPlatform, "reason", reason, "version", opts.clusterVersion, "source", source)
 
 			err = sched.Remove(env, sched.Options{
-				Platform:         opts.clusterPlatform,
-				WaitCompletion:   opts.waitCompletion,
-				Replicas:         int32(commonOpts.Replicas),
-				RTEConfigData:    commonOpts.RTEConfigData,
-				PullIfNotPresent: commonOpts.PullIfNotPresent,
+				Platform:          opts.clusterPlatform,
+				WaitCompletion:    opts.waitCompletion,
+				Replicas:          int32(commonOpts.Replicas),
+				RTEConfigData:     commonOpts.RTEConfigData,
+				PullIfNotPresent:  commonOpts.PullIfNotPresent,
+				CacheResyncPeriod: commonOpts.schedResyncPeriod,
 			})
 			if err != nil {
 				// intentionally keep going to remove as much as possible
@@ -176,11 +177,12 @@ func NewDeploySchedulerPluginCommand(commonOpts *CommonOptions, opts *DeployOpti
 
 			commonOpts.DebugLog.Info("detection", "platform", opts.clusterPlatform, "reason", reason, "version", opts.clusterVersion, "source", source)
 			return sched.Deploy(env, sched.Options{
-				Platform:         opts.clusterPlatform,
-				WaitCompletion:   opts.waitCompletion,
-				Replicas:         int32(commonOpts.Replicas),
-				RTEConfigData:    commonOpts.RTEConfigData,
-				PullIfNotPresent: commonOpts.PullIfNotPresent,
+				Platform:          opts.clusterPlatform,
+				WaitCompletion:    opts.waitCompletion,
+				Replicas:          int32(commonOpts.Replicas),
+				RTEConfigData:     commonOpts.RTEConfigData,
+				PullIfNotPresent:  commonOpts.PullIfNotPresent,
+				CacheResyncPeriod: commonOpts.schedResyncPeriod,
 			})
 		},
 		Args: cobra.NoArgs,
@@ -284,11 +286,12 @@ func NewRemoveSchedulerPluginCommand(commonOpts *CommonOptions, opts *DeployOpti
 
 			commonOpts.DebugLog.Info("detection", "platform", opts.clusterPlatform, "reason", reason, "version", opts.clusterVersion, "source", source)
 			return sched.Remove(env, sched.Options{
-				Platform:         opts.clusterPlatform,
-				WaitCompletion:   opts.waitCompletion,
-				Replicas:         int32(commonOpts.Replicas),
-				RTEConfigData:    commonOpts.RTEConfigData,
-				PullIfNotPresent: commonOpts.PullIfNotPresent,
+				Platform:          opts.clusterPlatform,
+				WaitCompletion:    opts.waitCompletion,
+				Replicas:          int32(commonOpts.Replicas),
+				RTEConfigData:     commonOpts.RTEConfigData,
+				PullIfNotPresent:  commonOpts.PullIfNotPresent,
+				CacheResyncPeriod: commonOpts.schedResyncPeriod,
 			})
 		},
 		Args: cobra.NoArgs,
@@ -368,11 +371,12 @@ func deployOnCluster(commonOpts *CommonOptions, opts *DeployOptions) error {
 		return err
 	}
 	if err := sched.Deploy(env, sched.Options{
-		Platform:         opts.clusterPlatform,
-		WaitCompletion:   opts.waitCompletion,
-		Replicas:         int32(commonOpts.Replicas),
-		RTEConfigData:    commonOpts.RTEConfigData,
-		PullIfNotPresent: commonOpts.PullIfNotPresent,
+		Platform:          opts.clusterPlatform,
+		WaitCompletion:    opts.waitCompletion,
+		Replicas:          int32(commonOpts.Replicas),
+		RTEConfigData:     commonOpts.RTEConfigData,
+		PullIfNotPresent:  commonOpts.PullIfNotPresent,
+		CacheResyncPeriod: commonOpts.schedResyncPeriod,
 	}); err != nil {
 		return err
 	}

--- a/pkg/deployer/sched/sched.go
+++ b/pkg/deployer/sched/sched.go
@@ -18,6 +18,7 @@ package sched
 
 import (
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -27,11 +28,12 @@ import (
 )
 
 type Options struct {
-	Platform         platform.Platform
-	WaitCompletion   bool
-	Replicas         int32
-	RTEConfigData    string
-	PullIfNotPresent bool
+	Platform          platform.Platform
+	WaitCompletion    bool
+	Replicas          int32
+	RTEConfigData     string
+	PullIfNotPresent  bool
+	CacheResyncPeriod time.Duration
 }
 
 func SetupNamespace(plat platform.Platform) (*corev1.Namespace, string, error) {
@@ -49,8 +51,9 @@ func Deploy(env *deployer.Environment, opts Options) error {
 	}
 
 	mf, err = mf.Render(env.Log, schedmanifests.RenderOptions{
-		Replicas:         opts.Replicas,
-		PullIfNotPresent: opts.PullIfNotPresent,
+		Replicas:          opts.Replicas,
+		PullIfNotPresent:  opts.PullIfNotPresent,
+		CacheResyncPeriod: opts.CacheResyncPeriod,
 	})
 	if err != nil {
 		return err
@@ -84,8 +87,9 @@ func Remove(env *deployer.Environment, opts Options) error {
 	}
 
 	mf, err = mf.Render(env.Log, schedmanifests.RenderOptions{
-		Replicas:         opts.Replicas,
-		PullIfNotPresent: opts.PullIfNotPresent,
+		Replicas:          opts.Replicas,
+		PullIfNotPresent:  opts.PullIfNotPresent,
+		CacheResyncPeriod: opts.CacheResyncPeriod,
 	})
 	if err != nil {
 		return err

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -391,12 +391,10 @@ func DaemonSet(component, subComponent string, plat platform.Platform, namespace
 			c := &ds.Spec.Template.Spec.Containers[i]
 			if c.Name == ContainerNameRTE {
 				c.Image = images.ResourceTopologyExporterImage
-				// we do this explicitely, but should be already OK from the YAML manifest
-				c.Command = []string{
-					"/bin/resource-topology-exporter",
-				}
+
 				c.Args = []string{
 					"--sleep-interval=10s",
+					"--pods-fingerprint",
 					fmt.Sprintf("--sysfs=%s", containerHostSysDir),
 					fmt.Sprintf("--podresources-socket=unix://%s", containerPodResourcesSocket),
 					fmt.Sprintf("--notify-file=/%s/%s", rteNotifierVolumeName, rteNotifierFileName),


### PR DESCRIPTION
grab bag of fixes meant to enable the shceduler plugin reserve cache: inconditionally enable the pods-fingerprinting RTE support (until https://github.com/k8stopologyawareschedwg/deployer/issues/153 is fixed). Properly pass through the stack the user setting, otherwise the option has no effect.