### PR TITLE
selinux: update ocp policies

### DIFF
--- a/pkg/assets/rte/selinuxpolicy/ocp_v4.11.cil
+++ b/pkg/assets/rte/selinuxpolicy/ocp_v4.11.cil
@@ -8,12 +8,15 @@
 	(typeattributeset container_net_domain (process))
 	(typeattributeset svirt_sandbox_domain (process))
 	(typeattributeset sandbox_net_domain (process))
-
+	; MCS is leveraged by container_t and others, like us, to prevent cross-pod communication.
+	(typeattributeset mcs_constrained_type (process))
+	;
+	; Allow access to procfs (also needed by libraries)
+	(allow process proc_type (file (open read)))
 	;
 	; Allow to RTE pod access to /run/rte directory
 	(allow process container_var_run_t (dir (add_name write)))
 	(allow process container_var_run_t (file (create read write open)))
-
 	;
 	; Allow to RTE pod connect, read and write permissions to /var/lib/kubelet/pod-resource/kubelet.sock
 	(allow process container_var_lib_t (sock_file (open getattr read write ioctl lock append)))

--- a/pkg/assets/rte/selinuxpolicy/ocp_v4.12.cil
+++ b/pkg/assets/rte/selinuxpolicy/ocp_v4.12.cil
@@ -8,12 +8,15 @@
 	(typeattributeset container_net_domain (process))
 	(typeattributeset svirt_sandbox_domain (process))
 	(typeattributeset sandbox_net_domain (process))
-
+	; MCS is leveraged by container_t and others, like us, to prevent cross-pod communication.
+	(typeattributeset mcs_constrained_type (process))
+	;
+	; Allow access to procfs (also needed by libraries)
+	(allow process proc_type (file (open read)))
 	;
 	; Allow to RTE pod access to /run/rte directory
 	(allow process container_var_run_t (dir (add_name write)))
 	(allow process container_var_run_t (file (create read write open)))
-
 	;
 	; Allow to RTE pod connect, read and write permissions to /var/lib/kubelet/pod-resource/kubelet.sock
 	(allow process container_var_lib_t (sock_file (open getattr read write ioctl lock append)))

--- a/pkg/assets/rte/selinuxpolicy/ocp_v4.13.cil
+++ b/pkg/assets/rte/selinuxpolicy/ocp_v4.13.cil
@@ -8,14 +8,18 @@
 	(typeattributeset container_net_domain (process))
 	(typeattributeset svirt_sandbox_domain (process))
 	(typeattributeset sandbox_net_domain (process))
-
+	; MCS is leveraged by container_t and others, like us, to prevent cross-pod communication.
+	(typeattributeset mcs_constrained_type (process))
+	;
+	; Allow access to procfs (also needed by libraries)
+	(allow process proc_type (file (open read)))
 	;
 	; Allow to RTE pod access to /run/rte directory
 	(allow process container_var_run_t (dir (add_name write)))
 	(allow process container_var_run_t (file (create read write open)))
-
 	;
 	; Allow to RTE pod connect, read and write permissions to /var/lib/kubelet/pod-resource/kubelet.sock
 	(allow process container_var_lib_t (sock_file (open getattr read write ioctl lock append)))
-	(allow process kubelet_t (unix_stream_socket (connectto)))
+	(allow process container_var_lib_t (unix_stream_socket (connectto)))
+	(allow process unconfined_service_t (unix_stream_socket (connectto)))
 )


### PR DESCRIPTION
catch up with container-selinux v2.188 and 2.199