### PR TITLE
introduce objectupdate common structs to reduce layers

### DIFF
--- a/pkg/commands/deploy.go
+++ b/pkg/commands/deploy.go
@@ -90,12 +90,11 @@ func NewRemoveCommand(commonOpts *CommonOptions) *cobra.Command {
 				commonOpts.Log.Info("while removing", "error", err)
 			}
 			err = updaters.Remove(env, commonOpts.UpdaterType, updaters.Options{
-				Platform:         opts.clusterPlatform,
-				PlatformVersion:  opts.clusterVersion,
-				WaitCompletion:   opts.waitCompletion,
-				PullIfNotPresent: commonOpts.PullIfNotPresent,
-				PFPEnable:        commonOpts.UpdaterPFPEnable,
-				RTEConfigData:    commonOpts.RTEConfigData,
+				Platform:        opts.clusterPlatform,
+				PlatformVersion: opts.clusterVersion,
+				WaitCompletion:  opts.waitCompletion,
+				RTEConfigData:   commonOpts.RTEConfigData,
+				DaemonSet:       daemonSetOptionsFromCommonOptions(commonOpts),
 			})
 			if err != nil {
 				// intentionally keep going to remove as much as possible
@@ -216,12 +215,11 @@ func NewDeployTopologyUpdaterCommand(commonOpts *CommonOptions, opts *DeployOpti
 
 			commonOpts.DebugLog.Info("detection", "platform", opts.clusterPlatform, "reason", reason, "version", opts.clusterVersion, "source", source)
 			return updaters.Deploy(env, commonOpts.UpdaterType, updaters.Options{
-				Platform:         opts.clusterPlatform,
-				PlatformVersion:  opts.clusterVersion,
-				WaitCompletion:   opts.waitCompletion,
-				PullIfNotPresent: commonOpts.PullIfNotPresent,
-				PFPEnable:        commonOpts.UpdaterPFPEnable,
-				RTEConfigData:    commonOpts.RTEConfigData,
+				Platform:        opts.clusterPlatform,
+				PlatformVersion: opts.clusterVersion,
+				WaitCompletion:  opts.waitCompletion,
+				RTEConfigData:   commonOpts.RTEConfigData,
+				DaemonSet:       daemonSetOptionsFromCommonOptions(commonOpts),
 			})
 		},
 		Args: cobra.NoArgs,
@@ -326,12 +324,11 @@ func NewRemoveTopologyUpdaterCommand(commonOpts *CommonOptions, opts *DeployOpti
 
 			commonOpts.DebugLog.Info("detection", "platform", opts.clusterPlatform, "reason", reason, "version", opts.clusterVersion, "source", source)
 			return updaters.Remove(env, commonOpts.UpdaterType, updaters.Options{
-				Platform:         opts.clusterPlatform,
-				PlatformVersion:  opts.clusterVersion,
-				WaitCompletion:   opts.waitCompletion,
-				PullIfNotPresent: commonOpts.PullIfNotPresent,
-				PFPEnable:        commonOpts.UpdaterPFPEnable,
-				RTEConfigData:    commonOpts.RTEConfigData,
+				Platform:        opts.clusterPlatform,
+				PlatformVersion: opts.clusterVersion,
+				WaitCompletion:  opts.waitCompletion,
+				RTEConfigData:   commonOpts.RTEConfigData,
+				DaemonSet:       daemonSetOptionsFromCommonOptions(commonOpts),
 			})
 		},
 		Args: cobra.NoArgs,
@@ -365,12 +362,11 @@ func deployOnCluster(commonOpts *CommonOptions, opts *DeployOptions) error {
 		return err
 	}
 	if err := updaters.Deploy(env, commonOpts.UpdaterType, updaters.Options{
-		Platform:         opts.clusterPlatform,
-		PlatformVersion:  opts.clusterVersion,
-		WaitCompletion:   opts.waitCompletion,
-		PullIfNotPresent: commonOpts.PullIfNotPresent,
-		PFPEnable:        commonOpts.UpdaterPFPEnable,
-		RTEConfigData:    commonOpts.RTEConfigData,
+		Platform:        opts.clusterPlatform,
+		PlatformVersion: opts.clusterVersion,
+		WaitCompletion:  opts.waitCompletion,
+		RTEConfigData:   commonOpts.RTEConfigData,
+		DaemonSet:       daemonSetOptionsFromCommonOptions(commonOpts),
 	}); err != nil {
 		return err
 	}

--- a/pkg/commands/render.go
+++ b/pkg/commands/render.go
@@ -134,11 +134,10 @@ func makeUpdaterObjects(commonOpts *CommonOptions) ([]client.Object, string, err
 	}
 
 	opts := updaters.Options{
-		PlatformVersion:  commonOpts.UserPlatformVersion,
-		Platform:         commonOpts.UserPlatform,
-		PullIfNotPresent: commonOpts.PullIfNotPresent,
-		RTEConfigData:    commonOpts.RTEConfigData,
-		PFPEnable:        commonOpts.UpdaterPFPEnable,
+		PlatformVersion: commonOpts.UserPlatformVersion,
+		Platform:        commonOpts.UserPlatform,
+		RTEConfigData:   commonOpts.RTEConfigData,
+		DaemonSet:       daemonSetOptionsFromCommonOptions(commonOpts),
 	}
 	objs, err := updaters.GetObjects(opts, commonOpts.UpdaterType, namespace)
 	if err != nil {

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -33,6 +33,7 @@ import (
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/updaters"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/objectupdate"
 )
 
 // TODO: move elsewhere
@@ -166,4 +167,11 @@ func environFromOpts(commonOpts *CommonOptions) (*deployer.Environment, error) {
 		Cli: cli,
 		Log: commonOpts.Log,
 	}, nil
+}
+
+func daemonSetOptionsFromCommonOptions(commonOpts *CommonOptions) objectupdate.DaemonSetOptions {
+	return objectupdate.DaemonSetOptions{
+		PullIfNotPresent: commonOpts.PullIfNotPresent,
+		PFPEnable:        commonOpts.UpdaterPFPEnable,
+	}
 }

--- a/pkg/deployer/updaters/objects.go
+++ b/pkg/deployer/updaters/objects.go
@@ -107,17 +107,15 @@ func getDeletableObjects(env *deployer.Environment, opts Options, updaterType, n
 
 func rteOptionsFrom(opts Options, namespace string) rtemanifests.RenderOptions {
 	return rtemanifests.RenderOptions{
-		ConfigData:       opts.RTEConfigData,
-		PullIfNotPresent: opts.PullIfNotPresent,
-		Namespace:        namespace,
-		PFPEnable:        opts.PFPEnable,
+		ConfigData: opts.RTEConfigData,
+		DaemonSet:  opts.DaemonSet,
+		Namespace:  namespace,
 	}
 }
 
 func nfdOptionsFrom(opts Options, namespace string) nfdmanifests.RenderOptions {
 	return nfdmanifests.RenderOptions{
-		PullIfNotPresent: opts.PullIfNotPresent,
-		Namespace:        namespace,
-		PFPEnable:        opts.PFPEnable,
+		Namespace: namespace,
+		DaemonSet: opts.DaemonSet,
 	}
 }

--- a/pkg/deployer/updaters/updaters.go
+++ b/pkg/deployer/updaters/updaters.go
@@ -26,6 +26,7 @@ import (
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/wait"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/manifests"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/objectupdate"
 )
 
 const (
@@ -34,12 +35,11 @@ const (
 )
 
 type Options struct {
-	Platform         platform.Platform
-	PlatformVersion  platform.Version
-	WaitCompletion   bool
-	PullIfNotPresent bool
-	RTEConfigData    string
-	PFPEnable        bool
+	Platform        platform.Platform
+	PlatformVersion platform.Version
+	WaitCompletion  bool
+	RTEConfigData   string
+	DaemonSet       objectupdate.DaemonSetOptions
 }
 
 func Deploy(env *deployer.Environment, updaterType string, opts Options) error {

--- a/pkg/flagcodec/flagcodec.go
+++ b/pkg/flagcodec/flagcodec.go
@@ -1,0 +1,143 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ */
+
+// flagcodec allows to manipulate foreign command lines following the
+// standard golang conventions. It offeres two-way processing aka
+// parsing/marshalling of flags. It is different from the other, well
+// established packages (pflag...) because it aims to manipulate command
+// lines in general, not this program command line.
+
+package flagcodec
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	FlagToggle = iota
+	FlagOption
+)
+
+type Val struct {
+	Kind int
+	Data string
+}
+
+type Flags struct {
+	command string
+	args    map[string]Val
+	keys    []string
+}
+
+func ParseArgvKeyValue(args []string) *Flags {
+	return ParseArgvKeyValueWithCommand("", args)
+}
+
+// ParseArgvKeyValue parses a clean (trimmed) argv whose components are
+// either toggles or key=value pairs. IOW, this is a restricted and easier
+// to parse flavour of argv on which option and value are guaranteed to
+// be in the same item.
+// IOW, we expect
+// "--opt=foo"
+// AND NOT
+// "--opt", "foo"
+func ParseArgvKeyValueWithCommand(command string, args []string) *Flags {
+	ret := &Flags{
+		command: command,
+		args:    make(map[string]Val),
+	}
+	for _, arg := range args {
+		fields := strings.SplitN(arg, "=", 2)
+		if len(fields) == 1 {
+			ret.SetToggle(fields[0])
+			continue
+		}
+		ret.SetOption(fields[0], fields[1])
+	}
+	return ret
+}
+
+func (fl *Flags) recordFlag(name string) {
+	if _, ok := fl.args[name]; !ok {
+		fl.keys = append(fl.keys, name)
+	}
+}
+
+func (fl *Flags) forgetFlag(name string) {
+	var keys []string
+	for _, k := range fl.keys {
+		if k == name {
+			continue
+		}
+		keys = append(keys, k)
+	}
+	fl.keys = keys
+}
+
+func (fl *Flags) SetToggle(name string) {
+	fl.recordFlag(name)
+	fl.args[name] = Val{
+		Kind: FlagToggle,
+	}
+}
+
+func (fl *Flags) SetOption(name, data string) {
+	fl.recordFlag(name)
+	fl.args[name] = Val{
+		Kind: FlagOption,
+		Data: data,
+	}
+}
+
+func (fl *Flags) Delete(name string) {
+	fl.forgetFlag(name)
+	delete(fl.args, name)
+}
+
+func (fl *Flags) Command() string {
+	return fl.command
+}
+
+func (fl *Flags) Args() []string {
+	var args []string
+	for _, name := range fl.keys {
+		args = append(args, toString(name, fl.args[name]))
+	}
+	return args
+}
+
+func (fl *Flags) Argv() []string {
+	args := fl.Args()
+	if fl.command == "" {
+		return args
+	}
+	return append([]string{fl.Command()}, args...)
+}
+
+func (fl *Flags) GetFlag(name string) (Val, bool) {
+	if val, ok := fl.args[name]; ok {
+		return val, ok
+	}
+	return Val{}, false
+}
+
+func toString(name string, val Val) string {
+	if val.Kind == FlagToggle {
+		return name
+	}
+	return fmt.Sprintf("%s=%s", name, val.Data)
+}

--- a/pkg/flagcodec/flagcodec_test.go
+++ b/pkg/flagcodec/flagcodec_test.go
@@ -1,0 +1,202 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ */
+
+package flagcodec
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseStringRoundTrip(t *testing.T) {
+	type testCase struct {
+		name     string
+		command  string
+		args     []string
+		expected []string
+	}
+
+	testCases := []testCase{
+		{
+			name: "nil",
+		},
+		{
+			name: "empty",
+			args: []string{},
+		},
+		{
+			name:    "only command",
+			command: "/bin/true",
+			expected: []string{
+				"/bin/true",
+			},
+		},
+		{
+			name:    "simple",
+			command: "/bin/resource-topology-exporter",
+			args: []string{
+				"--sleep-interval=10s",
+				"--sysfs=/host-sys",
+				"--kubelet-state-dir=/host-var/lib/kubelet",
+				"--podresources-socket=unix:///host-var/lib/kubelet/pod-resources/kubelet.sock",
+			},
+			expected: []string{
+				"/bin/resource-topology-exporter",
+				"--sleep-interval=10s",
+				"--sysfs=/host-sys",
+				"--kubelet-state-dir=/host-var/lib/kubelet",
+				"--podresources-socket=unix:///host-var/lib/kubelet/pod-resources/kubelet.sock",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fl := ParseArgvKeyValueWithCommand(tc.command, tc.args)
+			got := fl.Argv()
+			if !reflect.DeepEqual(tc.expected, got) {
+				t.Errorf("expected %v got %v", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestAddFlags(t *testing.T) {
+	type testOpt struct {
+		name  string
+		value string
+	}
+
+	type testCase struct {
+		name     string
+		command  string
+		args     []string
+		options  []testOpt
+		expected []string
+	}
+
+	testCases := []testCase{
+		{
+			name:    "add-mixed",
+			command: "/bin/resource-topology-exporter",
+			args: []string{
+				"--sleep-interval=10s",
+				"--sysfs=/host-sys",
+				"--kubelet-state-dir=/host-var/lib/kubelet",
+				"--podresources-socket=unix:///host-var/lib/kubelet/pod-resources/kubelet.sock",
+			},
+			options: []testOpt{
+				{
+					name:  "--hostname",
+					value: "host.test.net",
+				},
+				{
+					name:  "--v",
+					value: "2",
+				},
+			},
+			expected: []string{
+				"/bin/resource-topology-exporter",
+				"--sleep-interval=10s",
+				"--sysfs=/host-sys",
+				"--kubelet-state-dir=/host-var/lib/kubelet",
+				"--podresources-socket=unix:///host-var/lib/kubelet/pod-resources/kubelet.sock",
+				"--hostname=host.test.net",
+				"--v=2",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fl := ParseArgvKeyValueWithCommand(tc.command, tc.args)
+			for _, opt := range tc.options {
+				fl.SetOption(opt.name, opt.value)
+			}
+			got := fl.Argv()
+			if !reflect.DeepEqual(tc.expected, got) {
+				t.Errorf("expected %v got %v", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestDeleteFlags(t *testing.T) {
+
+	type testCase struct {
+		name     string
+		command  string
+		args     []string
+		options  []string
+		expected []string
+	}
+
+	testCases := []testCase{
+		{
+			name:    "remove-option",
+			command: "/bin/resource-topology-exporter",
+			args: []string{
+				"--sleep-interval=10s",
+				"--sysfs=/host-sys",
+				"--kubelet-state-dir=/host-var/lib/kubelet",
+				"--podresources-socket=unix:///host-var/lib/kubelet/pod-resources/kubelet.sock",
+			},
+			options: []string{
+				"--sleep-interval",
+			},
+			expected: []string{
+				"/bin/resource-topology-exporter",
+				"--sysfs=/host-sys",
+				"--kubelet-state-dir=/host-var/lib/kubelet",
+				"--podresources-socket=unix:///host-var/lib/kubelet/pod-resources/kubelet.sock",
+			},
+		},
+		{
+			name:    "remove-toggle",
+			command: "/bin/resource-topology-exporter",
+			args: []string{
+				"--sleep-interval=10s",
+				"--sysfs=/host-sys",
+				"--kubelet-state-dir=/host-var/lib/kubelet",
+				"--podresources-socket=unix:///host-var/lib/kubelet/pod-resources/kubelet.sock",
+				"--pods-fingerprint",
+			},
+			options: []string{
+				"--pods-fingerprint",
+			},
+			expected: []string{
+				"/bin/resource-topology-exporter",
+				"--sleep-interval=10s",
+				"--sysfs=/host-sys",
+				"--kubelet-state-dir=/host-var/lib/kubelet",
+				"--podresources-socket=unix:///host-var/lib/kubelet/pod-resources/kubelet.sock",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fl := ParseArgvKeyValueWithCommand(tc.command, tc.args)
+			for _, opt := range tc.options {
+				fl.Delete(opt)
+			}
+			got := fl.Argv()
+			if !reflect.DeepEqual(tc.expected, got) {
+				t.Errorf("expected %v got %v", tc.expected, got)
+			}
+		})
+	}
+}

--- a/pkg/manifests/nfd/nfd.go
+++ b/pkg/manifests/nfd/nfd.go
@@ -24,13 +24,13 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/wait"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/manifests"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/objectupdate"
 	nfdupdate "github.com/k8stopologyawareschedwg/deployer/pkg/objectupdate/nfd"
 	rbacupdate "github.com/k8stopologyawareschedwg/deployer/pkg/objectupdate/rbac"
 )
@@ -59,15 +59,13 @@ func (mf Manifests) Clone() Manifests {
 }
 
 type RenderOptions struct {
-	PullIfNotPresent bool
-	// DaemonSet option
-	NodeSelector *metav1.LabelSelector
+	DaemonSet objectupdate.DaemonSetOptions
+
 	// Deployment option
 	Replicas int32
 
 	// General options
 	Namespace string
-	PFPEnable bool
 }
 
 func (mf Manifests) Render(options RenderOptions) (Manifests, error) {
@@ -81,7 +79,7 @@ func (mf Manifests) Render(options RenderOptions) (Manifests, error) {
 
 	ret.DSTopologyUpdater.Spec.Template.Spec.ServiceAccountName = mf.SATopologyUpdater.Name
 
-	nfdupdate.UpdaterDaemonSet(ret.DSTopologyUpdater, options.PullIfNotPresent, options.PFPEnable, options.NodeSelector)
+	nfdupdate.UpdaterDaemonSet(ret.DSTopologyUpdater, options.DaemonSet)
 
 	return ret, nil
 }

--- a/pkg/manifests/rte/rte.go
+++ b/pkg/manifests/rte/rte.go
@@ -33,6 +33,7 @@ import (
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/wait"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/manifests"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/objectupdate"
 	ocpupdate "github.com/k8stopologyawareschedwg/deployer/pkg/objectupdate/ocp"
 	rbacupdate "github.com/k8stopologyawareschedwg/deployer/pkg/objectupdate/rbac"
 	rteupdate "github.com/k8stopologyawareschedwg/deployer/pkg/objectupdate/rte"
@@ -82,8 +83,7 @@ func (mf Manifests) Clone() Manifests {
 
 type RenderOptions struct {
 	// DaemonSet options
-	PullIfNotPresent bool
-	NodeSelector     *metav1.LabelSelector
+	DaemonSet objectupdate.DaemonSetOptions
 
 	// MachineConfig options
 	MachineConfigPoolSelector *metav1.LabelSelector
@@ -94,7 +94,6 @@ type RenderOptions struct {
 	// General options
 	Namespace string
 	Name      string
-	PFPEnable bool
 }
 
 func (mf Manifests) Render(options RenderOptions) (Manifests, error) {
@@ -127,7 +126,7 @@ func (mf Manifests) Render(options RenderOptions) (Manifests, error) {
 	if ret.ConfigMap != nil {
 		rteConfigMapName = ret.ConfigMap.Name
 	}
-	rteupdate.DaemonSet(ret.DaemonSet, rteConfigMapName, options.PullIfNotPresent, options.PFPEnable, options.NodeSelector)
+	rteupdate.DaemonSet(ret.DaemonSet, rteConfigMapName, options.DaemonSet)
 
 	if mf.plat == platform.OpenShift {
 		if options.Name != "" {

--- a/pkg/objectupdate/nfd/nfd.go
+++ b/pkg/objectupdate/nfd/nfd.go
@@ -19,31 +19,31 @@ package nfd
 import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/k8stopologyawareschedwg/deployer/pkg/images"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/manifests"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/objectupdate"
 )
 
-func UpdaterDaemonSet(ds *appsv1.DaemonSet, pullIfNotPresent, pfpEnable bool, nodeSelector *metav1.LabelSelector) {
+func UpdaterDaemonSet(ds *appsv1.DaemonSet, opts objectupdate.DaemonSetOptions) {
 	for i := range ds.Spec.Template.Spec.Containers {
 		c := &ds.Spec.Template.Spec.Containers[i]
 		if c.Name != manifests.ContainerNameNFDTopologyUpdater {
 			continue
 		}
 		c.ImagePullPolicy = corev1.PullAlways
-		if pullIfNotPresent {
+		if opts.PullIfNotPresent {
 			c.ImagePullPolicy = corev1.PullIfNotPresent
 		}
 
-		if pfpEnable {
+		if opts.PFPEnable {
 			c.Args = append([]string{"--pods-fingerprint"}, c.Args...)
 		}
 
 		c.Image = images.NodeFeatureDiscoveryImage
 
 	}
-	if nodeSelector != nil {
-		ds.Spec.Template.Spec.NodeSelector = nodeSelector.MatchLabels
+	if opts.NodeSelector != nil {
+		ds.Spec.Template.Spec.NodeSelector = opts.NodeSelector.MatchLabels
 	}
 }

--- a/pkg/objectupdate/nfd/nfd.go
+++ b/pkg/objectupdate/nfd/nfd.go
@@ -20,6 +20,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/k8stopologyawareschedwg/deployer/pkg/flagcodec"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/images"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/manifests"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/objectupdate"
@@ -36,9 +37,11 @@ func UpdaterDaemonSet(ds *appsv1.DaemonSet, opts objectupdate.DaemonSetOptions) 
 			c.ImagePullPolicy = corev1.PullIfNotPresent
 		}
 
+		flags := flagcodec.ParseArgvKeyValue(c.Args)
 		if opts.PFPEnable {
-			c.Args = append([]string{"--pods-fingerprint"}, c.Args...)
+			flags.SetToggle("--pods-fingerprint")
 		}
+		c.Args = flags.Argv()
 
 		c.Image = images.NodeFeatureDiscoveryImage
 

--- a/pkg/objectupdate/nfd/nfd_test.go
+++ b/pkg/objectupdate/nfd/nfd_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/k8stopologyawareschedwg/deployer/pkg/manifests"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/objectupdate"
 )
 
 func TestUpdaterDaemonSet(t *testing.T) {
@@ -58,7 +59,11 @@ func TestUpdaterDaemonSet(t *testing.T) {
 		mutatedDs := ds.DeepCopy()
 		pSpec := &mutatedDs.Spec.Template.Spec
 		pSpec.Containers[0].Name = tc.cntName
-		UpdaterDaemonSet(mutatedDs, tc.pullIfNotPresent, true, tc.nodeSelector)
+		UpdaterDaemonSet(mutatedDs, objectupdate.DaemonSetOptions{
+			PullIfNotPresent: tc.pullIfNotPresent,
+			PFPEnable:        true,
+			NodeSelector:     tc.nodeSelector,
+		})
 		if tc.cntName == manifests.ContainerNameNFDTopologyUpdater {
 			if pSpec.Containers[0].ImagePullPolicy != pullPolicy(tc.pullIfNotPresent) {
 				t.Errorf("expected container ImagePullPolicy to be: %q; got: %q", pullPolicy(tc.pullIfNotPresent), pSpec.Containers[0].ImagePullPolicy)

--- a/pkg/objectupdate/types.go
+++ b/pkg/objectupdate/types.go
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ */
+
+package objectupdate
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type DaemonSetOptions struct {
+	PullIfNotPresent bool
+	PFPEnable        bool
+	NodeSelector     *metav1.LabelSelector
+}


### PR DESCRIPTION
Instead of having per-layer struct, which leads to a lot of copying and most notably unnecessary complexity, define
generic cross-layer options struct and use them pervasively. 

Up until now the duplication proven to be cumbersome, for a change.
We will re-evaluate and inline later when/if there are clear benefits.

Along the way, use flagcodec to more robust argument processing when updating DaemonSets.
