### PR TITLE
manifests: push all mutations on objectupdate

### DIFF
--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -18,8 +18,6 @@ package manifests
 
 import (
 	"encoding/json"
-	"fmt"
-	"strings"
 	"testing"
 
 	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
@@ -433,124 +431,9 @@ func TestGetDaemonSet(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.component, func(t *testing.T) {
-			_, err := DaemonSet(tc.component, tc.subComponent, platform.Kubernetes, "")
+			_, err := DaemonSet(tc.component, tc.subComponent, "")
 			if (err != nil) != tc.expectError {
 				t.Fatalf("nil obj or non-nil err=%v", err)
-			}
-		})
-	}
-}
-
-func TestDaemonSet(t *testing.T) {
-	type testCase struct {
-		name                 string
-		plat                 platform.Platform
-		expectedCommandArgs  []string
-		expectedVolumes      map[string]string
-		expectedVolumeMounts map[string]string
-	}
-
-	containerPodResourcesSocket := fmt.Sprintf("/%s/kubelet.sock", rtePodresourcesSocketVolumeName)
-	containerHostSysDir := fmt.Sprintf("/%s", rteSysVolumeName)
-	testCases := []testCase{
-		{
-			name: "Verify DaemonSet generation for OpenShift platform",
-			plat: platform.OpenShift,
-			expectedCommandArgs: []string{
-				fmt.Sprintf("--sysfs=%s", containerHostSysDir),
-				fmt.Sprintf("--podresources-socket=unix://%s", containerPodResourcesSocket),
-				fmt.Sprintf("--notify-file=/%s/%s", rteNotifierVolumeName, rteNotifierFileName),
-			},
-			expectedVolumes: map[string]string{
-				rteSysVolumeName:                "/sys",
-				rtePodresourcesSocketVolumeName: "/var/lib/kubelet/pod-resources/kubelet.sock",
-				rteNotifierVolumeName:           "/run/rte",
-			},
-			expectedVolumeMounts: map[string]string{
-				rteSysVolumeName:                containerHostSysDir,
-				rtePodresourcesSocketVolumeName: containerPodResourcesSocket,
-				rteNotifierVolumeName:           fmt.Sprintf("/%s", rteNotifierVolumeName),
-			},
-		},
-		{
-			name: "Verify DaemonSet generation for Kubernetes platform",
-			plat: platform.Kubernetes,
-			expectedCommandArgs: []string{
-				fmt.Sprintf("--sysfs=%s", containerHostSysDir),
-				fmt.Sprintf("--podresources-socket=unix://%s", containerPodResourcesSocket),
-				fmt.Sprintf("--kubelet-config-file=/%s/config.yaml", rteKubeletDirVolumeName),
-				fmt.Sprintf("--kubelet-state-dir=/%s", rteKubeletDirVolumeName),
-				fmt.Sprintf("--notify-file=/%s/%s", rteNotifierVolumeName, rteNotifierFileName),
-			},
-			expectedVolumes: map[string]string{
-				rteSysVolumeName:                "/sys",
-				rtePodresourcesSocketVolumeName: "/var/lib/kubelet/pod-resources/kubelet.sock",
-				rteKubeletDirVolumeName:         "/var/lib/kubelet",
-				rteNotifierVolumeName:           "/run/rte",
-			},
-			expectedVolumeMounts: map[string]string{
-				rteSysVolumeName:                containerHostSysDir,
-				rtePodresourcesSocketVolumeName: containerPodResourcesSocket,
-				rteKubeletDirVolumeName:         fmt.Sprintf("/%s", rteKubeletDirVolumeName),
-				rteNotifierVolumeName:           fmt.Sprintf("/%s", rteNotifierVolumeName),
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			ds, err := DaemonSet(ComponentResourceTopologyExporter, "", tc.plat, "test")
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-
-			// we are expecting 3 volumes
-			// 1. Host sys
-			// 2. Pod resources socket file
-			// 3. RTE notifier directory
-			// 4. Kubelet directory only for Kubernetes platform
-			expectedVolumesNumber := 3
-			if tc.plat == platform.Kubernetes {
-				expectedVolumesNumber = 4
-			}
-			if len(ds.Spec.Template.Spec.Volumes) != expectedVolumesNumber {
-				klog.Errorf("the daemon set volumes: %+v", ds.Spec.Template.Spec.Volumes)
-				t.Fatalf("the daemon set has %d volumes when it should have %d", len(ds.Spec.Template.Spec.Volumes), expectedVolumesNumber)
-			}
-
-			for _, v := range ds.Spec.Template.Spec.Volumes {
-				path, ok := tc.expectedVolumes[v.Name]
-				if !ok {
-					t.Fatalf("the volume %q does not exist under expected volumes %v", v.Name, tc.expectedVolumes)
-				}
-
-				if v.HostPath.Path != path {
-					t.Fatalf("the volume %q path %q does not have expected value %q", v.Name, v.HostPath.Path, path)
-				}
-			}
-
-			rteContainer := ds.Spec.Template.Spec.Containers[0]
-			if len(rteContainer.VolumeMounts) != expectedVolumesNumber {
-				klog.Errorf("the daemon set container volume mounts: %+v", rteContainer.VolumeMounts)
-				t.Fatalf("the daemon set container has %d volume mounts when it should have %d", len(rteContainer.VolumeMounts), expectedVolumesNumber)
-			}
-
-			for _, m := range rteContainer.VolumeMounts {
-				path, ok := tc.expectedVolumeMounts[m.Name]
-				if !ok {
-					t.Fatalf("the volume mount %q does not exist under expected volumes mounts %v", m.Name, tc.expectedVolumeMounts)
-				}
-
-				if m.MountPath != path {
-					t.Fatalf("the volume mount %q path %q does not have expected value %q", m.Name, m.MountPath, path)
-				}
-			}
-
-			containerCommand := strings.Join(rteContainer.Args, " ")
-			for _, arg := range tc.expectedCommandArgs {
-				if !strings.Contains(containerCommand, arg) {
-					t.Fatalf("the container command %q does not container argument %q", containerCommand, arg)
-				}
 			}
 		})
 	}

--- a/pkg/manifests/nfd/nfd.go
+++ b/pkg/manifests/nfd/nfd.go
@@ -146,7 +146,7 @@ func GetManifests(plat platform.Platform, namespace string) (Manifests, error) {
 	if err != nil {
 		return mf, err
 	}
-	mf.DSTopologyUpdater, err = manifests.DaemonSet(manifests.ComponentNodeFeatureDiscovery, manifests.SubComponentNodeFeatureDiscoveryTopologyUpdater, plat, namespace)
+	mf.DSTopologyUpdater, err = manifests.DaemonSet(manifests.ComponentNodeFeatureDiscovery, manifests.SubComponentNodeFeatureDiscoveryTopologyUpdater, namespace)
 	if err != nil {
 		return mf, err
 	}

--- a/pkg/manifests/rte/rte.go
+++ b/pkg/manifests/rte/rte.go
@@ -126,9 +126,11 @@ func (mf Manifests) Render(options RenderOptions) (Manifests, error) {
 	if ret.ConfigMap != nil {
 		rteConfigMapName = ret.ConfigMap.Name
 	}
-	rteupdate.DaemonSet(ret.DaemonSet, rteConfigMapName, options.DaemonSet)
+	rteupdate.DaemonSet(ret.DaemonSet, mf.plat, rteConfigMapName, options.DaemonSet)
 
 	if mf.plat == platform.OpenShift {
+		rteupdate.SecurityContext(ret.DaemonSet)
+
 		if options.Name != "" {
 			ret.MachineConfig.Name = ocpupdate.MakeMachineConfigName(options.Name)
 		}
@@ -301,7 +303,7 @@ func GetManifests(plat platform.Platform, version platform.Version, namespace st
 	if err != nil {
 		return mf, err
 	}
-	mf.DaemonSet, err = manifests.DaemonSet(manifests.ComponentResourceTopologyExporter, "", plat, namespace)
+	mf.DaemonSet, err = manifests.DaemonSet(manifests.ComponentResourceTopologyExporter, "", namespace)
 	if err != nil {
 		return mf, err
 	}

--- a/pkg/objectupdate/rte/rte_test.go
+++ b/pkg/objectupdate/rte/rte_test.go
@@ -17,10 +17,16 @@
 package rte
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/manifests"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/objectupdate"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
 )
 
 func TestMetricsPort(t *testing.T) {
@@ -138,5 +144,121 @@ func TestAddConfigMapToPod(t *testing.T) {
 	}
 	if len(pod.Spec.Volumes) != 1 {
 		t.Errorf("missing volume declaration")
+	}
+}
+
+func TestDaemonSet(t *testing.T) {
+	type testCase struct {
+		name                 string
+		plat                 platform.Platform
+		expectedCommandArgs  []string
+		expectedVolumes      map[string]string
+		expectedVolumeMounts map[string]string
+	}
+
+	containerPodResourcesSocket := fmt.Sprintf("/%s/kubelet.sock", rtePodresourcesSocketVolumeName)
+	containerHostSysDir := fmt.Sprintf("/%s", rteSysVolumeName)
+	testCases := []testCase{
+		{
+			name: "Verify DaemonSet generation for OpenShift platform",
+			plat: platform.OpenShift,
+			expectedCommandArgs: []string{
+				fmt.Sprintf("--sysfs=%s", containerHostSysDir),
+				fmt.Sprintf("--podresources-socket=unix://%s", containerPodResourcesSocket),
+				fmt.Sprintf("--notify-file=/%s/%s", rteNotifierVolumeName, rteNotifierFileName),
+			},
+			expectedVolumes: map[string]string{
+				rteSysVolumeName:                "/sys",
+				rtePodresourcesSocketVolumeName: "/var/lib/kubelet/pod-resources/kubelet.sock",
+				rteNotifierVolumeName:           "/run/rte",
+			},
+			expectedVolumeMounts: map[string]string{
+				rteSysVolumeName:                containerHostSysDir,
+				rtePodresourcesSocketVolumeName: containerPodResourcesSocket,
+				rteNotifierVolumeName:           fmt.Sprintf("/%s", rteNotifierVolumeName),
+			},
+		},
+		{
+			name: "Verify DaemonSet generation for Kubernetes platform",
+			plat: platform.Kubernetes,
+			expectedCommandArgs: []string{
+				fmt.Sprintf("--sysfs=%s", containerHostSysDir),
+				fmt.Sprintf("--podresources-socket=unix://%s", containerPodResourcesSocket),
+				fmt.Sprintf("--kubelet-config-file=/%s/config.yaml", rteKubeletDirVolumeName),
+				fmt.Sprintf("--kubelet-state-dir=/%s", rteKubeletDirVolumeName),
+				fmt.Sprintf("--notify-file=/%s/%s", rteNotifierVolumeName, rteNotifierFileName),
+			},
+			expectedVolumes: map[string]string{
+				rteSysVolumeName:                "/sys",
+				rtePodresourcesSocketVolumeName: "/var/lib/kubelet/pod-resources/kubelet.sock",
+				rteKubeletDirVolumeName:         "/var/lib/kubelet",
+				rteNotifierVolumeName:           "/run/rte",
+			},
+			expectedVolumeMounts: map[string]string{
+				rteSysVolumeName:                containerHostSysDir,
+				rtePodresourcesSocketVolumeName: containerPodResourcesSocket,
+				rteKubeletDirVolumeName:         fmt.Sprintf("/%s", rteKubeletDirVolumeName),
+				rteNotifierVolumeName:           fmt.Sprintf("/%s", rteNotifierVolumeName),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ds, err := manifests.DaemonSet(manifests.ComponentResourceTopologyExporter, "", "test")
+			if err != nil {
+				t.Fatalf("unexpected error getting the manifests: %v", err)
+			}
+			DaemonSet(ds, tc.plat, "", objectupdate.DaemonSetOptions{})
+
+			// we are expecting 3 volumes
+			// 1. Host sys
+			// 2. Pod resources socket file
+			// 3. RTE notifier directory
+			// 4. Kubelet directory only for Kubernetes platform
+			expectedVolumesNumber := 3
+			if tc.plat == platform.Kubernetes {
+				expectedVolumesNumber = 4
+			}
+			if len(ds.Spec.Template.Spec.Volumes) != expectedVolumesNumber {
+				klog.Errorf("the daemon set volumes: %+v", ds.Spec.Template.Spec.Volumes)
+				t.Fatalf("the daemon set has %d volumes when it should have %d", len(ds.Spec.Template.Spec.Volumes), expectedVolumesNumber)
+			}
+
+			for _, v := range ds.Spec.Template.Spec.Volumes {
+				path, ok := tc.expectedVolumes[v.Name]
+				if !ok {
+					t.Fatalf("the volume %q does not exist under expected volumes %v", v.Name, tc.expectedVolumes)
+				}
+
+				if v.HostPath.Path != path {
+					t.Fatalf("the volume %q path %q does not have expected value %q", v.Name, v.HostPath.Path, path)
+				}
+			}
+
+			rteContainer := ds.Spec.Template.Spec.Containers[0]
+			if len(rteContainer.VolumeMounts) != expectedVolumesNumber {
+				klog.Errorf("the daemon set container volume mounts: %+v", rteContainer.VolumeMounts)
+				t.Fatalf("the daemon set container has %d volume mounts when it should have %d", len(rteContainer.VolumeMounts), expectedVolumesNumber)
+			}
+
+			for _, m := range rteContainer.VolumeMounts {
+				path, ok := tc.expectedVolumeMounts[m.Name]
+				if !ok {
+					t.Fatalf("the volume mount %q does not exist under expected volumes mounts %v", m.Name, tc.expectedVolumeMounts)
+				}
+
+				if m.MountPath != path {
+					t.Fatalf("the volume mount %q path %q does not have expected value %q", m.Name, m.MountPath, path)
+				}
+			}
+
+			containerCommand := strings.Join(rteContainer.Args, " ")
+			for _, arg := range tc.expectedCommandArgs {
+				if !strings.Contains(containerCommand, arg) {
+					t.Fatalf("the container command %q does not container argument %q", containerCommand, arg)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
the manifests package should perform only minimal mutation, and only if/where needed.

RTE daemonset was an exception for legacy reasons, not by deliberate design. At long last, move mutations (and their tests) in the objectupdate/rte package.