### PR TITLE
topologyupdaters: add more tunings

### DIFF
--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -40,6 +40,7 @@ import (
 const (
 	DefaultSchedulerProfileName  = "topology-aware-scheduler"
 	DefaultSchedulerResyncPeriod = 0 * time.Second
+	DefaultUpdaterSyncPeriod     = 10 * time.Second
 )
 
 type CommonOptions struct {
@@ -53,6 +54,8 @@ type CommonOptions struct {
 	PullIfNotPresent    bool
 	UpdaterType         string
 	UpdaterPFPEnable    bool
+	UpdaterNotifEnable  bool
+	UpdaterSyncPeriod   time.Duration
 	rteConfigFile       string
 	plat                string
 	platVer             string
@@ -111,6 +114,8 @@ func InitFlags(flags *pflag.FlagSet, commonOpts *CommonOptions) {
 	flags.StringVar(&commonOpts.rteConfigFile, "rte-config-file", "", "inject rte configuration reading from this file.")
 	flags.StringVar(&commonOpts.UpdaterType, "updater-type", "RTE", "type of updater to deploy - RTE or NFD")
 	flags.BoolVar(&commonOpts.UpdaterPFPEnable, "updater-pfp-enable", true, "toggle PFP support on the updater side.")
+	flags.BoolVar(&commonOpts.UpdaterNotifEnable, "updater-notif-enable", true, "toggle event-based notification support on the updater side.")
+	flags.DurationVar(&commonOpts.UpdaterSyncPeriod, "updater-sync-period", DefaultUpdaterSyncPeriod, "tune the updater synchronization (nrt update) interval. Use 0 to disable.")
 	flags.StringVar(&commonOpts.schedProfileName, "sched-profile-name", DefaultSchedulerProfileName, "inject scheduler profile name.")
 	flags.DurationVar(&commonOpts.schedResyncPeriod, "sched-resync-period", DefaultSchedulerResyncPeriod, "inject scheduler resync period.")
 }
@@ -171,7 +176,9 @@ func environFromOpts(commonOpts *CommonOptions) (*deployer.Environment, error) {
 
 func daemonSetOptionsFromCommonOptions(commonOpts *CommonOptions) objectupdate.DaemonSetOptions {
 	return objectupdate.DaemonSetOptions{
-		PullIfNotPresent: commonOpts.PullIfNotPresent,
-		PFPEnable:        commonOpts.UpdaterPFPEnable,
+		PullIfNotPresent:   commonOpts.PullIfNotPresent,
+		PFPEnable:          commonOpts.UpdaterPFPEnable,
+		NotificationEnable: commonOpts.UpdaterNotifEnable,
+		UpdateInterval:     commonOpts.UpdaterSyncPeriod,
 	}
 }

--- a/pkg/objectupdate/nfd/nfd.go
+++ b/pkg/objectupdate/nfd/nfd.go
@@ -17,6 +17,8 @@
 package nfd
 
 import (
+	"fmt"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 
@@ -34,6 +36,11 @@ func UpdaterDaemonSet(ds *appsv1.DaemonSet, opts objectupdate.DaemonSetOptions) 
 		}
 
 		flags := flagcodec.ParseArgvKeyValue(c.Args)
+		if opts.UpdateInterval > 0 {
+			flags.SetOption("--sleep-interval", fmt.Sprintf("%v", opts.UpdateInterval))
+		} else {
+			flags.Delete("--sleep-interval")
+		}
 		if opts.PFPEnable {
 			flags.SetToggle("--pods-fingerprint")
 		}

--- a/pkg/objectupdate/rte/rte_test.go
+++ b/pkg/objectupdate/rte/rte_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/manifests"
@@ -209,7 +210,11 @@ func TestDaemonSet(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error getting the manifests: %v", err)
 			}
-			DaemonSet(ds, tc.plat, "", objectupdate.DaemonSetOptions{})
+			DaemonSet(ds, tc.plat, "", objectupdate.DaemonSetOptions{
+				PFPEnable:          true,
+				NotificationEnable: true,
+				UpdateInterval:     10 * time.Second,
+			})
 
 			// we are expecting 3 volumes
 			// 1. Host sys

--- a/pkg/objectupdate/types.go
+++ b/pkg/objectupdate/types.go
@@ -17,11 +17,15 @@
 package objectupdate
 
 import (
+	"time"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type DaemonSetOptions struct {
-	PullIfNotPresent bool
-	PFPEnable        bool
-	NodeSelector     *metav1.LabelSelector
+	PullIfNotPresent   bool
+	PFPEnable          bool
+	NotificationEnable bool
+	NodeSelector       *metav1.LabelSelector
+	UpdateInterval     time.Duration
 }


### PR DESCRIPTION
add top-level options to:
- tune the update (sleep) interval - use 0 to disable
- disable the notification mechanism (e.g. enable only polling)