### PR TITLE
updaters: add option to control verbosity

### DIFF
--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -56,6 +56,7 @@ type CommonOptions struct {
 	UpdaterPFPEnable    bool
 	UpdaterNotifEnable  bool
 	UpdaterSyncPeriod   time.Duration
+	UpdaterVerbose      int
 	rteConfigFile       string
 	plat                string
 	platVer             string
@@ -116,6 +117,7 @@ func InitFlags(flags *pflag.FlagSet, commonOpts *CommonOptions) {
 	flags.BoolVar(&commonOpts.UpdaterPFPEnable, "updater-pfp-enable", true, "toggle PFP support on the updater side.")
 	flags.BoolVar(&commonOpts.UpdaterNotifEnable, "updater-notif-enable", true, "toggle event-based notification support on the updater side.")
 	flags.DurationVar(&commonOpts.UpdaterSyncPeriod, "updater-sync-period", DefaultUpdaterSyncPeriod, "tune the updater synchronization (nrt update) interval. Use 0 to disable.")
+	flags.IntVar(&commonOpts.UpdaterVerbose, "updater-verbose", 1, "set the updater verbosiness.")
 	flags.StringVar(&commonOpts.schedProfileName, "sched-profile-name", DefaultSchedulerProfileName, "inject scheduler profile name.")
 	flags.DurationVar(&commonOpts.schedResyncPeriod, "sched-resync-period", DefaultSchedulerResyncPeriod, "inject scheduler resync period.")
 }
@@ -180,5 +182,6 @@ func daemonSetOptionsFromCommonOptions(commonOpts *CommonOptions) objectupdate.D
 		PFPEnable:          commonOpts.UpdaterPFPEnable,
 		NotificationEnable: commonOpts.UpdaterNotifEnable,
 		UpdateInterval:     commonOpts.UpdaterSyncPeriod,
+		Verbose:            commonOpts.UpdaterVerbose,
 	}
 }

--- a/pkg/objectupdate/nfd/nfd.go
+++ b/pkg/objectupdate/nfd/nfd.go
@@ -36,6 +36,7 @@ func UpdaterDaemonSet(ds *appsv1.DaemonSet, opts objectupdate.DaemonSetOptions) 
 		}
 
 		flags := flagcodec.ParseArgvKeyValue(c.Args)
+		flags.SetOption("-v", fmt.Sprintf("%d", opts.Verbose))
 		if opts.UpdateInterval > 0 {
 			flags.SetOption("--sleep-interval", fmt.Sprintf("%v", opts.UpdateInterval))
 		} else {

--- a/pkg/objectupdate/rte/rte.go
+++ b/pkg/objectupdate/rte/rte.go
@@ -126,6 +126,7 @@ func DaemonSet(ds *appsv1.DaemonSet, plat platform.Platform, configMapName strin
 		}
 
 		flags := flagcodec.ParseArgvKeyValue(cntSpec.Args)
+		flags.SetOption("-v", fmt.Sprintf("%d", opts.Verbose))
 		if opts.UpdateInterval > 0 {
 			flags.SetOption("--sleep-interval", fmt.Sprintf("%v", opts.UpdateInterval))
 		} else {

--- a/pkg/objectupdate/types.go
+++ b/pkg/objectupdate/types.go
@@ -23,6 +23,7 @@ import (
 )
 
 type DaemonSetOptions struct {
+	Verbose            int
 	PullIfNotPresent   bool
 	PFPEnable          bool
 	NotificationEnable bool


### PR DESCRIPTION
Add top-level option to control the updaters verbosity Support for scheduler verbosity is planned for later series.

Fixes #175 