### PR TITLE
[release-0.13][manual] rte: always mount kubelet config

### DIFF
--- a/pkg/objectupdate/rte/rte.go
+++ b/pkg/objectupdate/rte/rte.go
@@ -116,13 +116,11 @@ func DaemonSet(ds *appsv1.DaemonSet, plat platform.Platform, configMapName strin
 					},
 				},
 			})
-			if opts.NotificationEnable {
-				rteContainerVolumeMounts = append(rteContainerVolumeMounts, corev1.VolumeMount{
-					Name:      rteKubeletDirVolumeName,
-					ReadOnly:  true,
-					MountPath: filepath.Join("/", rteKubeletDirVolumeName),
-				})
-			}
+			rteContainerVolumeMounts = append(rteContainerVolumeMounts, corev1.VolumeMount{
+				Name:      rteKubeletDirVolumeName,
+				ReadOnly:  true,
+				MountPath: filepath.Join("/", rteKubeletDirVolumeName),
+			})
 		}
 
 		flags := flagcodec.ParseArgvKeyValue(cntSpec.Args)


### PR DESCRIPTION
We need to always mount the kubelet config volume
on kubernetes, even if notification is disabled.
Notification enablement should only control the RTE option.