### PR TITLE
hack: minikube: fixups and docs

### DIFF
--- a/hack/setup-minikube.sh
+++ b/hack/setup-minikube.sh
@@ -66,6 +66,9 @@ minikube ssh \
 	sudo bash /bin/fix-kubeletconf.sh
 done
 
+# to emphasize the reserve cache behavior:
+#     deployer deploy topology-updater --rte-config-file ./rte-minikube.yaml  --updater-notif-enable=false --updater-sync-period=15s
+
 echo "#>>> setup done! now run:"
 echo "deployer deploy api"
 echo "deployer deploy topology-updater --rte-config-file ./rte-minikube.yaml"

--- a/hack/setup-minikube.sh
+++ b/hack/setup-minikube.sh
@@ -69,3 +69,4 @@ done
 echo "#>>> setup done! now run:"
 echo "deployer deploy api"
 echo "deployer deploy topology-updater --rte-config-file ./rte-minikube.yaml"
+echo "deployer deploy scheduler-plugin --sched-resync-period 5s"


### PR DESCRIPTION
clarify and add missing recommendations about setting up the env.