### PR TITLE
updaters: add toggle to deploy CRI hooks

### DIFF
--- a/pkg/commands/deploy.go
+++ b/pkg/commands/deploy.go
@@ -95,6 +95,7 @@ func NewRemoveCommand(commonOpts *CommonOptions) *cobra.Command {
 				WaitCompletion:  opts.waitCompletion,
 				RTEConfigData:   commonOpts.RTEConfigData,
 				DaemonSet:       daemonSetOptionsFromCommonOptions(commonOpts),
+				EnableCRIHooks:  commonOpts.UpdaterCRIHooksEnable,
 			})
 			if err != nil {
 				// intentionally keep going to remove as much as possible
@@ -220,6 +221,7 @@ func NewDeployTopologyUpdaterCommand(commonOpts *CommonOptions, opts *DeployOpti
 				WaitCompletion:  opts.waitCompletion,
 				RTEConfigData:   commonOpts.RTEConfigData,
 				DaemonSet:       daemonSetOptionsFromCommonOptions(commonOpts),
+				EnableCRIHooks:  commonOpts.UpdaterCRIHooksEnable,
 			})
 		},
 		Args: cobra.NoArgs,
@@ -329,6 +331,7 @@ func NewRemoveTopologyUpdaterCommand(commonOpts *CommonOptions, opts *DeployOpti
 				WaitCompletion:  opts.waitCompletion,
 				RTEConfigData:   commonOpts.RTEConfigData,
 				DaemonSet:       daemonSetOptionsFromCommonOptions(commonOpts),
+				EnableCRIHooks:  commonOpts.UpdaterCRIHooksEnable,
 			})
 		},
 		Args: cobra.NoArgs,
@@ -367,6 +370,7 @@ func deployOnCluster(commonOpts *CommonOptions, opts *DeployOptions) error {
 		WaitCompletion:  opts.waitCompletion,
 		RTEConfigData:   commonOpts.RTEConfigData,
 		DaemonSet:       daemonSetOptionsFromCommonOptions(commonOpts),
+		EnableCRIHooks:  commonOpts.UpdaterCRIHooksEnable,
 	}); err != nil {
 		return err
 	}

--- a/pkg/commands/render.go
+++ b/pkg/commands/render.go
@@ -138,6 +138,7 @@ func makeUpdaterObjects(commonOpts *CommonOptions) ([]client.Object, string, err
 		Platform:        commonOpts.UserPlatform,
 		RTEConfigData:   commonOpts.RTEConfigData,
 		DaemonSet:       daemonSetOptionsFromCommonOptions(commonOpts),
+		EnableCRIHooks:  commonOpts.UpdaterCRIHooksEnable,
 	}
 	objs, err := updaters.GetObjects(opts, commonOpts.UpdaterType, namespace)
 	if err != nil {

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -44,24 +44,25 @@ const (
 )
 
 type CommonOptions struct {
-	Debug               bool
-	UserPlatform        platform.Platform
-	UserPlatformVersion platform.Version
-	Log                 logr.Logger
-	DebugLog            logr.Logger
-	Replicas            int
-	RTEConfigData       string
-	PullIfNotPresent    bool
-	UpdaterType         string
-	UpdaterPFPEnable    bool
-	UpdaterNotifEnable  bool
-	UpdaterSyncPeriod   time.Duration
-	UpdaterVerbose      int
-	SchedProfileName    string
-	SchedResyncPeriod   time.Duration
-	rteConfigFile       string
-	plat                string
-	platVer             string
+	Debug                 bool
+	UserPlatform          platform.Platform
+	UserPlatformVersion   platform.Version
+	Log                   logr.Logger
+	DebugLog              logr.Logger
+	Replicas              int
+	RTEConfigData         string
+	PullIfNotPresent      bool
+	UpdaterType           string
+	UpdaterPFPEnable      bool
+	UpdaterNotifEnable    bool
+	UpdaterCRIHooksEnable bool
+	UpdaterSyncPeriod     time.Duration
+	UpdaterVerbose        int
+	SchedProfileName      string
+	SchedResyncPeriod     time.Duration
+	rteConfigFile         string
+	plat                  string
+	platVer               string
 }
 
 func ShowHelp(cmd *cobra.Command, args []string) error {
@@ -116,6 +117,7 @@ func InitFlags(flags *pflag.FlagSet, commonOpts *CommonOptions) {
 	flags.StringVar(&commonOpts.UpdaterType, "updater-type", "RTE", "type of updater to deploy - RTE or NFD")
 	flags.BoolVar(&commonOpts.UpdaterPFPEnable, "updater-pfp-enable", true, "toggle PFP support on the updater side.")
 	flags.BoolVar(&commonOpts.UpdaterNotifEnable, "updater-notif-enable", true, "toggle event-based notification support on the updater side.")
+	flags.BoolVar(&commonOpts.UpdaterCRIHooksEnable, "updater-cri-hooks-enable", true, "toggle installation of CRI hooks on the updater side.")
 	flags.DurationVar(&commonOpts.UpdaterSyncPeriod, "updater-sync-period", DefaultUpdaterSyncPeriod, "tune the updater synchronization (nrt update) interval. Use 0 to disable.")
 	flags.IntVar(&commonOpts.UpdaterVerbose, "updater-verbose", 1, "set the updater verbosiness.")
 	flags.StringVar(&commonOpts.SchedProfileName, "sched-profile-name", DefaultSchedulerProfileName, "inject scheduler profile name.")

--- a/pkg/deployer/updaters/objects.go
+++ b/pkg/deployer/updaters/objects.go
@@ -29,7 +29,7 @@ import (
 func GetObjects(opts Options, updaterType, namespace string) ([]client.Object, error) {
 
 	if updaterType == RTE {
-		mf, err := rtemanifests.GetManifests(opts.Platform, opts.PlatformVersion, namespace)
+		mf, err := rtemanifests.GetManifests(opts.Platform, opts.PlatformVersion, namespace, opts.EnableCRIHooks)
 		if err != nil {
 			return nil, err
 		}
@@ -55,7 +55,7 @@ func GetObjects(opts Options, updaterType, namespace string) ([]client.Object, e
 
 func getCreatableObjects(env *deployer.Environment, opts Options, updaterType, namespace string) ([]deployer.WaitableObject, error) {
 	if updaterType == RTE {
-		mf, err := rtemanifests.GetManifests(opts.Platform, opts.PlatformVersion, namespace)
+		mf, err := rtemanifests.GetManifests(opts.Platform, opts.PlatformVersion, namespace, opts.EnableCRIHooks)
 		if err != nil {
 			return nil, err
 		}
@@ -81,7 +81,7 @@ func getCreatableObjects(env *deployer.Environment, opts Options, updaterType, n
 
 func getDeletableObjects(env *deployer.Environment, opts Options, updaterType, namespace string) ([]deployer.WaitableObject, error) {
 	if updaterType == RTE {
-		mf, err := rtemanifests.GetManifests(opts.Platform, opts.PlatformVersion, namespace)
+		mf, err := rtemanifests.GetManifests(opts.Platform, opts.PlatformVersion, namespace, opts.EnableCRIHooks)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/deployer/updaters/updaters.go
+++ b/pkg/deployer/updaters/updaters.go
@@ -40,6 +40,7 @@ type Options struct {
 	WaitCompletion  bool
 	RTEConfigData   string
 	DaemonSet       objectupdate.DaemonSetOptions
+	EnableCRIHooks  bool
 }
 
 func Deploy(env *deployer.Environment, updaterType string, opts Options) error {

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -307,7 +307,7 @@ func DaemonSet(component, subComponent string, namespace string) (*appsv1.Daemon
 	return ds, nil
 }
 
-func MachineConfig(component string, ver platform.Version) (*machineconfigv1.MachineConfig, error) {
+func MachineConfig(component string, ver platform.Version, withCRIHooks bool) (*machineconfigv1.MachineConfig, error) {
 	if component != ComponentResourceTopologyExporter {
 		return nil, fmt.Errorf("component %q is not an %q component", component, ComponentResourceTopologyExporter)
 	}
@@ -322,7 +322,7 @@ func MachineConfig(component string, ver platform.Version) (*machineconfigv1.Mac
 		return nil, fmt.Errorf("unexpected type, got %t", obj)
 	}
 
-	ignitionConfig, err := getIgnitionConfig(ver)
+	ignitionConfig, err := makeIgnitionConfig(ver, withCRIHooks)
 	if err != nil {
 		return nil, err
 	}
@@ -331,42 +331,43 @@ func MachineConfig(component string, ver platform.Version) (*machineconfigv1.Mac
 	return mc, nil
 }
 
-func getIgnitionConfig(ver platform.Version) ([]byte, error) {
+func makeIgnitionConfig(ver platform.Version, withCRIHooks bool) ([]byte, error) {
 	var files []igntypes.File
 
-	// get SELinux policy
+	if withCRIHooks {
+		// load RTE notifier OCI hook config
+		notifierHookConfigContent, err := getTemplateContent(rteassets.HookConfigRTENotifier, map[string]string{
+			templateNotifierBinaryDst: filepath.Join(defaultScriptsDir, rteassets.NotifierScriptName),
+			templateNotifierFilePath:  filepath.Join(rteassets.HostNotifierDir, rteassets.NotifierFileName),
+		})
+		if err != nil {
+			return nil, err
+		}
+		files = addFileToIgnitionConfig(
+			files,
+			notifierHookConfigContent,
+			0644,
+			filepath.Join(defaultOCIHooksDir, rteassets.NotifierOCIHookConfig),
+		)
+
+		// load RTE notifier script
+		files = addFileToIgnitionConfig(
+			files,
+			rteassets.NotifierScript,
+			0755,
+			filepath.Join(defaultScriptsDir, rteassets.NotifierScriptName),
+		)
+	}
+
+	// we always need the SELinux policy
 	selinuxPolicy, err := selinuxassets.GetPolicy(ver)
 	if err != nil {
 		return nil, err
 	}
 
-	// load SELinux policy
 	files = addFileToIgnitionConfig(files, selinuxPolicy, 0644, selinuxassets.RTEPolicyFileName)
 
-	// load RTE notifier OCI hook config
-	notifierHookConfigContent, err := getTemplateContent(rteassets.HookConfigRTENotifier, map[string]string{
-		templateNotifierBinaryDst: filepath.Join(defaultScriptsDir, rteassets.NotifierScriptName),
-		templateNotifierFilePath:  filepath.Join(rteassets.HostNotifierDir, rteassets.NotifierFileName),
-	})
-	if err != nil {
-		return nil, err
-	}
-	files = addFileToIgnitionConfig(
-		files,
-		notifierHookConfigContent,
-		0644,
-		filepath.Join(defaultOCIHooksDir, rteassets.NotifierOCIHookConfig),
-	)
-
-	// load RTE notifier script
-	files = addFileToIgnitionConfig(
-		files,
-		rteassets.NotifierScript,
-		0755,
-		filepath.Join(defaultScriptsDir, rteassets.NotifierScriptName),
-	)
-
-	// load systemd service to install SELinux policy
+	// and while we (always) need the SELinuc policy, we also need to make sure it's installed
 	systemdServiceContent, err := getTemplateContent(
 		selinuxassets.InstallSystemdServiceTemplate,
 		map[string]string{
@@ -393,12 +394,7 @@ func getIgnitionConfig(ver platform.Version) ([]byte, error) {
 		},
 	}
 
-	rawIgnition, err := json.Marshal(ignitionConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	return rawIgnition, nil
+	return json.Marshal(ignitionConfig)
 }
 
 func addFileToIgnitionConfig(files []igntypes.File, fileContent []byte, mode int, fileDst string) []igntypes.File {

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -444,6 +444,7 @@ func TestMachineConfig(t *testing.T) {
 	type testCase struct {
 		name            string
 		platformVersion platform.Version
+		enableCRIHooks  bool
 		expectedFileNum int
 		expectedUnitNum int
 	}
@@ -461,20 +462,29 @@ func TestMachineConfig(t *testing.T) {
 		{
 			name:            "OCP 4.10",
 			platformVersion: "v4.10",
+			enableCRIHooks:  true,
 			expectedFileNum: 3,
 			expectedUnitNum: 1,
 		},
 		{
 			name:            "OCP 4.11",
 			platformVersion: "v4.11",
+			enableCRIHooks:  true,
 			expectedFileNum: 3,
+			expectedUnitNum: 1,
+		},
+		{
+			name:            "OCP 4.11",
+			platformVersion: "v4.11",
+			enableCRIHooks:  false,
+			expectedFileNum: 1,
 			expectedUnitNum: 1,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			mc, err := MachineConfig(ComponentResourceTopologyExporter, platform.Version(tc.platformVersion))
+			mc, err := MachineConfig(ComponentResourceTopologyExporter, platform.Version(tc.platformVersion), tc.enableCRIHooks)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/pkg/manifests/rte/rte.go
+++ b/pkg/manifests/rte/rte.go
@@ -267,12 +267,12 @@ func New(plat platform.Platform) Manifests {
 	return mf
 }
 
-func GetManifests(plat platform.Platform, version platform.Version, namespace string) (Manifests, error) {
+func GetManifests(plat platform.Platform, version platform.Version, namespace string, withCRIHooks bool) (Manifests, error) {
 	var err error
 	mf := New(plat)
 
 	if plat == platform.OpenShift {
-		mf.MachineConfig, err = manifests.MachineConfig(manifests.ComponentResourceTopologyExporter, version)
+		mf.MachineConfig, err = manifests.MachineConfig(manifests.ComponentResourceTopologyExporter, version, withCRIHooks)
 		if err != nil {
 			return mf, err
 		}

--- a/pkg/manifests/rte/rte_test.go
+++ b/pkg/manifests/rte/rte_test.go
@@ -55,7 +55,7 @@ func TestClone(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc.mf, _ = GetManifests(tc.plat, tc.platVersion, "")
+		tc.mf, _ = GetManifests(tc.plat, tc.platVersion, "", true)
 		cMf := tc.mf.Clone()
 
 		if &cMf == &tc.mf {
@@ -96,7 +96,7 @@ func TestRender(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc.mf, _ = GetManifests(tc.plat, tc.platVersion, "")
+		tc.mf, _ = GetManifests(tc.plat, tc.platVersion, "", true)
 		mfBeforeRender := tc.mf.Clone()
 		uMf, err := tc.mf.Render(RenderOptions{})
 		if err != nil {
@@ -133,7 +133,7 @@ func TestGetManifestsOpenShift(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		mf, err := GetManifests(tc.plat, tc.platVersion, "test")
+		mf, err := GetManifests(tc.plat, tc.platVersion, "test", true)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/test/e2e/negative.go
+++ b/test/e2e/negative.go
@@ -96,7 +96,8 @@ var _ = ginkgo.Describe("[NegativeFlow] Deployer execution with PFP disabled", f
 				ns, err := manifests.Namespace(manifests.ComponentResourceTopologyExporter)
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-				mf, err := rte.GetManifests(platform.Kubernetes, platform.Version("1.23"), ns.Name)
+				enableCRIHooks := true
+				mf, err := rte.GetManifests(platform.Kubernetes, platform.Version("1.23"), ns.Name, enableCRIHooks)
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 				mf, err = mf.Render(rte.RenderOptions{
 					Namespace: ns.Name,

--- a/test/e2e/positive.go
+++ b/test/e2e/positive.go
@@ -248,7 +248,8 @@ var _ = ginkgo.Describe("[PositiveFlow] Deployer execution", func() {
 				ns, err := manifests.Namespace(manifests.ComponentResourceTopologyExporter)
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-				mf, err := rte.GetManifests(platform.Kubernetes, platform.Version("1.23"), ns.Name)
+				enableCRIHooks := true
+				mf, err := rte.GetManifests(platform.Kubernetes, platform.Version("1.23"), ns.Name, enableCRIHooks)
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 				mf, err = mf.Render(rte.RenderOptions{
 					Namespace: ns.Name,


### PR DESCRIPTION
The CRI hooks are unconditionally deployed, but that creates waste when the event-based notification mechanism is not enabled. We should expose a way to enable the callers to disable the deployment of CRI hooks to avoid unnecessary churn.