### PR TITLE
scheduler: add option to control verbosity

### DIFF
--- a/pkg/commands/deploy.go
+++ b/pkg/commands/deploy.go
@@ -184,6 +184,7 @@ func NewDeploySchedulerPluginCommand(commonOpts *CommonOptions, opts *DeployOpti
 				RTEConfigData:     commonOpts.RTEConfigData,
 				PullIfNotPresent:  commonOpts.PullIfNotPresent,
 				CacheResyncPeriod: commonOpts.SchedResyncPeriod,
+				Verbose:           commonOpts.SchedVerbose,
 			})
 		},
 		Args: cobra.NoArgs,
@@ -294,6 +295,7 @@ func NewRemoveSchedulerPluginCommand(commonOpts *CommonOptions, opts *DeployOpti
 				RTEConfigData:     commonOpts.RTEConfigData,
 				PullIfNotPresent:  commonOpts.PullIfNotPresent,
 				CacheResyncPeriod: commonOpts.SchedResyncPeriod,
+				Verbose:           commonOpts.SchedVerbose,
 			})
 		},
 		Args: cobra.NoArgs,
@@ -381,6 +383,7 @@ func deployOnCluster(commonOpts *CommonOptions, opts *DeployOptions) error {
 		RTEConfigData:     commonOpts.RTEConfigData,
 		PullIfNotPresent:  commonOpts.PullIfNotPresent,
 		CacheResyncPeriod: commonOpts.SchedResyncPeriod,
+		Verbose:           commonOpts.SchedVerbose,
 	}); err != nil {
 		return err
 	}

--- a/pkg/commands/render.go
+++ b/pkg/commands/render.go
@@ -177,6 +177,7 @@ func RenderManifests(commonOpts *CommonOptions) error {
 		PullIfNotPresent:  commonOpts.PullIfNotPresent,
 		ProfileName:       commonOpts.SchedProfileName,
 		CacheResyncPeriod: commonOpts.SchedResyncPeriod,
+		Verbose:           commonOpts.SchedVerbose,
 	}
 
 	schedObjs, err := schedManifests.Render(commonOpts.Log, schedRenderOpts)

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -60,6 +60,7 @@ type CommonOptions struct {
 	UpdaterVerbose        int
 	SchedProfileName      string
 	SchedResyncPeriod     time.Duration
+	SchedVerbose          int
 	rteConfigFile         string
 	plat                  string
 	platVer               string
@@ -122,6 +123,7 @@ func InitFlags(flags *pflag.FlagSet, commonOpts *CommonOptions) {
 	flags.IntVar(&commonOpts.UpdaterVerbose, "updater-verbose", 1, "set the updater verbosiness.")
 	flags.StringVar(&commonOpts.SchedProfileName, "sched-profile-name", DefaultSchedulerProfileName, "inject scheduler profile name.")
 	flags.DurationVar(&commonOpts.SchedResyncPeriod, "sched-resync-period", DefaultSchedulerResyncPeriod, "inject scheduler resync period.")
+	flags.IntVar(&commonOpts.SchedVerbose, "sched-verbose", 4, "set the scheduler verbosiness.")
 }
 
 func PostSetupOptions(commonOpts *CommonOptions) error {

--- a/pkg/deployer/sched/sched.go
+++ b/pkg/deployer/sched/sched.go
@@ -34,6 +34,7 @@ type Options struct {
 	RTEConfigData     string
 	PullIfNotPresent  bool
 	CacheResyncPeriod time.Duration
+	Verbose           int
 }
 
 func SetupNamespace(plat platform.Platform) (*corev1.Namespace, string, error) {
@@ -54,6 +55,7 @@ func Deploy(env *deployer.Environment, opts Options) error {
 		Replicas:          opts.Replicas,
 		PullIfNotPresent:  opts.PullIfNotPresent,
 		CacheResyncPeriod: opts.CacheResyncPeriod,
+		Verbose:           opts.Verbose,
 	})
 	if err != nil {
 		return err
@@ -90,6 +92,7 @@ func Remove(env *deployer.Environment, opts Options) error {
 		Replicas:          opts.Replicas,
 		PullIfNotPresent:  opts.PullIfNotPresent,
 		CacheResyncPeriod: opts.CacheResyncPeriod,
+		Verbose:           opts.Verbose,
 	})
 	if err != nil {
 		return err

--- a/pkg/manifests/sched/sched.go
+++ b/pkg/manifests/sched/sched.go
@@ -88,6 +88,7 @@ type RenderOptions struct {
 	PullIfNotPresent  bool
 	ProfileName       string
 	CacheResyncPeriod time.Duration
+	Verbose           int
 }
 
 func (mf Manifests) Render(logger logr.Logger, options RenderOptions) (Manifests, error) {
@@ -104,7 +105,7 @@ func (mf Manifests) Render(logger logr.Logger, options RenderOptions) (Manifests
 		return ret, err
 	}
 
-	schedupdate.SchedulerDeployment(ret.DPScheduler, options.PullIfNotPresent)
+	schedupdate.SchedulerDeployment(ret.DPScheduler, options.PullIfNotPresent, options.Verbose)
 	schedupdate.ControllerDeployment(ret.DPController, options.PullIfNotPresent)
 	if mf.plat == platform.OpenShift {
 		ret.Namespace.Name = NamespaceOpenShift

--- a/pkg/objectupdate/sched/sched.go
+++ b/pkg/objectupdate/sched/sched.go
@@ -26,6 +26,7 @@ import (
 	schedconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
 	pluginconfig "sigs.k8s.io/scheduler-plugins/apis/config"
 
+	"github.com/k8stopologyawareschedwg/deployer/pkg/flagcodec"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/images"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/manifests"
 )
@@ -35,9 +36,15 @@ const (
 	schedulerPluginName     = "NodeResourceTopologyMatch"
 )
 
-func SchedulerDeployment(dp *appsv1.Deployment, pullIfNotPresent bool) {
-	dp.Spec.Template.Spec.Containers[0].Image = images.SchedulerPluginSchedulerImage
-	dp.Spec.Template.Spec.Containers[0].ImagePullPolicy = pullPolicy(pullIfNotPresent)
+func SchedulerDeployment(dp *appsv1.Deployment, pullIfNotPresent bool, verbose int) {
+	cnt := &dp.Spec.Template.Spec.Containers[0] // shortcut
+
+	cnt.Image = images.SchedulerPluginSchedulerImage
+	cnt.ImagePullPolicy = pullPolicy(pullIfNotPresent)
+
+	flags := flagcodec.ParseArgvKeyValue(cnt.Args)
+	flags.SetOption("--v", fmt.Sprintf("%d", verbose)) // TODO: keep in sync with the manifest (-v vs --v)
+	cnt.Args = flags.Argv()
 }
 
 func ControllerDeployment(dp *appsv1.Deployment, pullIfNotPresent bool) {


### PR DESCRIPTION
Add top-level option to control the scheduler verbosity. Note: the auxiliary scheduler controller is left out for now.

Fixes #189