### PR TITLE
sched: manifests: run on the control plane

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,6 +42,7 @@ jobs:
         kind create cluster --config=hack/kind-config-e2e-positive.yaml --image kindest/node:v1.26.4@sha256:f4c0d87be03d6bea69f5e5dc0adb678bb498a190ee5c38422bf751541cebe92e
         kubectl label node kind-worker node-role.kubernetes.io/worker=''
         hack/wait-nodes-ready.sh
+        kubectl describe nodes
 
     - name: run E2E tests
       run: |
@@ -77,6 +78,7 @@ jobs:
         kind create cluster --config=hack/kind-config-e2e-negative.yaml --image kindest/node:v1.26.4@sha256:f4c0d87be03d6bea69f5e5dc0adb678bb498a190ee5c38422bf751541cebe92e
         kubectl label node kind-worker node-role.kubernetes.io/worker=''
         hack/wait-nodes-ready.sh
+        kubectl describe nodes
 
     - name: run E2E tests
       run: |

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	k8s.io/utils v0.0.0-20221107191617-1a15be271d1d
 	sigs.k8s.io/controller-runtime v0.13.1
 	sigs.k8s.io/scheduler-plugins v0.24.9
+	sigs.k8s.io/yaml v1.3.0
 )
 
 require (
@@ -82,7 +83,6 @@ require (
 	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
-	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
 replace (

--- a/pkg/commands/deploy.go
+++ b/pkg/commands/deploy.go
@@ -84,6 +84,7 @@ func NewRemoveCommand(commonOpts *CommonOptions) *cobra.Command {
 				RTEConfigData:     commonOpts.RTEConfigData,
 				PullIfNotPresent:  commonOpts.PullIfNotPresent,
 				CacheResyncPeriod: commonOpts.SchedResyncPeriod,
+				CtrlPlaneAffinity: commonOpts.SchedCtrlPlaneAffinity,
 			})
 			if err != nil {
 				// intentionally keep going to remove as much as possible
@@ -184,6 +185,7 @@ func NewDeploySchedulerPluginCommand(commonOpts *CommonOptions, opts *DeployOpti
 				RTEConfigData:     commonOpts.RTEConfigData,
 				PullIfNotPresent:  commonOpts.PullIfNotPresent,
 				CacheResyncPeriod: commonOpts.SchedResyncPeriod,
+				CtrlPlaneAffinity: commonOpts.SchedCtrlPlaneAffinity,
 				Verbose:           commonOpts.SchedVerbose,
 			})
 		},
@@ -295,6 +297,7 @@ func NewRemoveSchedulerPluginCommand(commonOpts *CommonOptions, opts *DeployOpti
 				RTEConfigData:     commonOpts.RTEConfigData,
 				PullIfNotPresent:  commonOpts.PullIfNotPresent,
 				CacheResyncPeriod: commonOpts.SchedResyncPeriod,
+				CtrlPlaneAffinity: commonOpts.SchedCtrlPlaneAffinity,
 				Verbose:           commonOpts.SchedVerbose,
 			})
 		},
@@ -383,6 +386,7 @@ func deployOnCluster(commonOpts *CommonOptions, opts *DeployOptions) error {
 		RTEConfigData:     commonOpts.RTEConfigData,
 		PullIfNotPresent:  commonOpts.PullIfNotPresent,
 		CacheResyncPeriod: commonOpts.SchedResyncPeriod,
+		CtrlPlaneAffinity: commonOpts.SchedCtrlPlaneAffinity,
 		Verbose:           commonOpts.SchedVerbose,
 	}); err != nil {
 		return err

--- a/pkg/commands/render.go
+++ b/pkg/commands/render.go
@@ -177,6 +177,7 @@ func RenderManifests(commonOpts *CommonOptions) error {
 		PullIfNotPresent:  commonOpts.PullIfNotPresent,
 		ProfileName:       commonOpts.SchedProfileName,
 		CacheResyncPeriod: commonOpts.SchedResyncPeriod,
+		CtrlPlaneAffinity: commonOpts.SchedCtrlPlaneAffinity,
 		Verbose:           commonOpts.SchedVerbose,
 	}
 

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -44,26 +44,27 @@ const (
 )
 
 type CommonOptions struct {
-	Debug                 bool
-	UserPlatform          platform.Platform
-	UserPlatformVersion   platform.Version
-	Log                   logr.Logger
-	DebugLog              logr.Logger
-	Replicas              int
-	RTEConfigData         string
-	PullIfNotPresent      bool
-	UpdaterType           string
-	UpdaterPFPEnable      bool
-	UpdaterNotifEnable    bool
-	UpdaterCRIHooksEnable bool
-	UpdaterSyncPeriod     time.Duration
-	UpdaterVerbose        int
-	SchedProfileName      string
-	SchedResyncPeriod     time.Duration
-	SchedVerbose          int
-	rteConfigFile         string
-	plat                  string
-	platVer               string
+	Debug                  bool
+	UserPlatform           platform.Platform
+	UserPlatformVersion    platform.Version
+	Log                    logr.Logger
+	DebugLog               logr.Logger
+	Replicas               int
+	RTEConfigData          string
+	PullIfNotPresent       bool
+	UpdaterType            string
+	UpdaterPFPEnable       bool
+	UpdaterNotifEnable     bool
+	UpdaterCRIHooksEnable  bool
+	UpdaterSyncPeriod      time.Duration
+	UpdaterVerbose         int
+	SchedProfileName       string
+	SchedResyncPeriod      time.Duration
+	SchedVerbose           int
+	SchedCtrlPlaneAffinity bool
+	rteConfigFile          string
+	plat                   string
+	platVer                string
 }
 
 func ShowHelp(cmd *cobra.Command, args []string) error {
@@ -124,6 +125,7 @@ func InitFlags(flags *pflag.FlagSet, commonOpts *CommonOptions) {
 	flags.StringVar(&commonOpts.SchedProfileName, "sched-profile-name", DefaultSchedulerProfileName, "inject scheduler profile name.")
 	flags.DurationVar(&commonOpts.SchedResyncPeriod, "sched-resync-period", DefaultSchedulerResyncPeriod, "inject scheduler resync period.")
 	flags.IntVar(&commonOpts.SchedVerbose, "sched-verbose", 4, "set the scheduler verbosiness.")
+	flags.BoolVar(&commonOpts.SchedCtrlPlaneAffinity, "sched-ctrlplane-affinity", true, "toggle the scheduler control plane affinity.")
 }
 
 func PostSetupOptions(commonOpts *CommonOptions) error {

--- a/pkg/deployer/sched/sched.go
+++ b/pkg/deployer/sched/sched.go
@@ -34,6 +34,7 @@ type Options struct {
 	RTEConfigData     string
 	PullIfNotPresent  bool
 	CacheResyncPeriod time.Duration
+	CtrlPlaneAffinity bool
 	Verbose           int
 }
 
@@ -55,6 +56,7 @@ func Deploy(env *deployer.Environment, opts Options) error {
 		Replicas:          opts.Replicas,
 		PullIfNotPresent:  opts.PullIfNotPresent,
 		CacheResyncPeriod: opts.CacheResyncPeriod,
+		CtrlPlaneAffinity: opts.CtrlPlaneAffinity,
 		Verbose:           opts.Verbose,
 	})
 	if err != nil {
@@ -92,6 +94,7 @@ func Remove(env *deployer.Environment, opts Options) error {
 		Replicas:          opts.Replicas,
 		PullIfNotPresent:  opts.PullIfNotPresent,
 		CacheResyncPeriod: opts.CacheResyncPeriod,
+		CtrlPlaneAffinity: opts.CtrlPlaneAffinity,
 		Verbose:           opts.Verbose,
 	})
 	if err != nil {

--- a/pkg/manifests/sched/sched.go
+++ b/pkg/manifests/sched/sched.go
@@ -88,6 +88,7 @@ type RenderOptions struct {
 	PullIfNotPresent  bool
 	ProfileName       string
 	CacheResyncPeriod time.Duration
+	CtrlPlaneAffinity bool
 	Verbose           int
 }
 
@@ -105,8 +106,8 @@ func (mf Manifests) Render(logger logr.Logger, options RenderOptions) (Manifests
 		return ret, err
 	}
 
-	schedupdate.SchedulerDeployment(ret.DPScheduler, options.PullIfNotPresent, options.Verbose)
-	schedupdate.ControllerDeployment(ret.DPController, options.PullIfNotPresent)
+	schedupdate.SchedulerDeployment(ret.DPScheduler, options.PullIfNotPresent, options.CtrlPlaneAffinity, options.Verbose)
+	schedupdate.ControllerDeployment(ret.DPController, options.PullIfNotPresent, options.CtrlPlaneAffinity)
 	if mf.plat == platform.OpenShift {
 		ret.Namespace.Name = NamespaceOpenShift
 	}

--- a/pkg/objectupdate/affinity.go
+++ b/pkg/objectupdate/affinity.go
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ */
+
+package objectupdate
+
+import corev1 "k8s.io/api/core/v1"
+
+const (
+	NodeRoleControlPlane           = "node-role.kubernetes.io/control-plane"
+	NodeRoleControlPlaneDeprecated = "node-role.kubernetes.io/master"
+)
+
+func SetPodSchedulerAffinityOnControlPlane(podSpec *corev1.PodSpec) {
+	if podSpec == nil {
+		return
+	}
+
+	for _, label := range []string{
+		NodeRoleControlPlane,
+		NodeRoleControlPlaneDeprecated,
+	} {
+		if toleration := findTolerationByKey(podSpec.Tolerations, label); toleration == nil {
+			podSpec.Tolerations = append(podSpec.Tolerations, corev1.Toleration{
+				Key:    label,
+				Effect: corev1.TaintEffectNoSchedule,
+			})
+		}
+	}
+	if podSpec.Affinity == nil {
+		podSpec.Affinity = &corev1.Affinity{}
+	}
+	if podSpec.Affinity.NodeAffinity == nil {
+		podSpec.Affinity.NodeAffinity = &corev1.NodeAffinity{}
+	}
+	if podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = &corev1.NodeSelector{
+			NodeSelectorTerms: []corev1.NodeSelectorTerm{
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Key:      NodeRoleControlPlane,
+							Operator: corev1.NodeSelectorOpExists,
+						},
+					},
+				},
+			},
+		}
+	}
+}
+
+func findTolerationByKey(tolerations []corev1.Toleration, key string) *corev1.Toleration {
+	for idx := range tolerations {
+		toleration := &tolerations[idx]
+		if toleration.Key == key {
+			return toleration
+		}
+	}
+	return nil
+}

--- a/pkg/objectupdate/affinity_test.go
+++ b/pkg/objectupdate/affinity_test.go
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ */
+
+package objectupdate
+
+import (
+	"testing"
+
+	"sigs.k8s.io/yaml"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestSetPodSchedulerAffinityOnControlPlane(t *testing.T) {
+
+	type testCase struct {
+		name         string
+		podSpec      *corev1.PodSpec
+		expectedYAML string
+	}
+
+	testCases := []testCase{
+		{
+			name:         "nil",
+			expectedYAML: "null\n",
+		},
+		{
+			name:         "empty",
+			podSpec:      &corev1.PodSpec{},
+			expectedYAML: podSpecOnlyAffinity,
+		},
+		{
+			name: "partial affinity",
+			podSpec: &corev1.PodSpec{
+				Affinity: &corev1.Affinity{
+					NodeAffinity: &corev1.NodeAffinity{},
+				},
+			},
+			expectedYAML: podSpecOnlyAffinity,
+		},
+		{
+			name: "partial tolerations",
+			podSpec: &corev1.PodSpec{
+				Tolerations: []corev1.Toleration{
+					{
+						Key:    NodeRoleControlPlane,
+						Effect: corev1.TaintEffectNoSchedule,
+					},
+				},
+			},
+			expectedYAML: podSpecOnlyAffinity,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.podSpec.DeepCopy()
+			SetPodSchedulerAffinityOnControlPlane(got)
+			data, err := yaml.Marshal(got)
+			if err != nil {
+				t.Errorf("error marshalling yaml: %v", err)
+			}
+			gotYAML := string(data)
+			if gotYAML != tc.expectedYAML {
+				t.Errorf("output mismatch:\ngot=%v\nexpected=%v\n", gotYAML, tc.expectedYAML)
+			}
+		})
+	}
+}
+
+const podSpecOnlyAffinity = `affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+containers: null
+tolerations:
+- effect: NoSchedule
+  key: node-role.kubernetes.io/control-plane
+- effect: NoSchedule
+  key: node-role.kubernetes.io/master
+`

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -162,7 +162,11 @@ func deploy(updaterType string, pfpEnable bool) error {
 		cmdline = append(cmdline, updaterArg)
 	}
 	// TODO: use error wrapping
-	return runCmdline(cmdline, "failed to deploy components before test started")
+	err := runCmdline(cmdline, "failed to deploy components before test started")
+	if err != nil {
+		dumpSchedulerPods()
+	}
+	return err
 }
 
 func remove(updaterType string) error {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -155,6 +155,7 @@ func deploy(updaterType string, pfpEnable bool) error {
 		"deploy",
 		"--rte-config-file=" + filepath.Join(deployerBaseDir, "hack", "rte.yaml"),
 		"--updater-pfp-enable=" + strconv.FormatBool(pfpEnable),
+		"--sched-ctrlplane-affinity=false",
 		"--wait",
 	}
 	if updaterType != "" {

--- a/test/e2e/positive.go
+++ b/test/e2e/positive.go
@@ -444,7 +444,7 @@ var _ = ginkgo.Describe("[PositiveFlow] Deployer partial execution", func() {
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			err = runCmdline(
-				[]string{binPath, "--debug", "deploy", "scheduler-plugin", "--wait"},
+				[]string{binPath, "--debug", "deploy", "scheduler-plugin", "--sched-ctrlplane-affinity=false", "--wait"},
 				"failed to deploy partial components before test started",
 			)
 			if err != nil {
@@ -479,7 +479,7 @@ var _ = ginkgo.Describe("[PositiveFlow] Deployer partial execution", func() {
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			err = runCmdline(
-				[]string{binPath, "--debug", "--sched-verbose=9", "deploy", "scheduler-plugin", "--wait"},
+				[]string{binPath, "--debug", "--sched-verbose=9", "deploy", "scheduler-plugin", "--sched-ctrlplane-affinity=false", "--wait"},
 				"failed to deploy partial components before test started",
 			)
 			if err != nil {

--- a/test/e2e/utils/pods/events.go
+++ b/test/e2e/utils/pods/events.go
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ */
+
+package pods
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+)
+
+const (
+	envVarDumpEvents = "TAS_DUMP_EVENTS"
+)
+
+func LogEventsForPod(k8sCli kubernetes.Interface, ctx context.Context, podNamespace, podName string) error {
+	events, err := GetEventsForPod(k8sCli, ctx, podNamespace, podName)
+	if err != nil {
+		return err
+	}
+	klog.Infof("begin events for %s/%s", podNamespace, podName)
+	for _, item := range events {
+		klog.Infof("+- event: %s %s: %s %s", item.Type, item.ReportingController, item.Reason, item.Message)
+	}
+	klog.Infof("end events for %s/%s", podNamespace, podName)
+
+	if _, ok := os.LookupEnv(envVarDumpEvents); ok {
+		fmt.Println(DumpEventsForPod(events, podNamespace, podName))
+	}
+	return nil
+}
+
+func DumpEventsForPod(events []corev1.Event, podNamespace, podName string) string {
+	var buf strings.Builder
+	fmt.Fprintf(&buf, "begin event dump for %s/%s\n", podNamespace, podName)
+	for _, item := range events {
+		fmt.Fprintf(&buf, "+- event: %s %s: %s %s", item.Type, item.ReportingController, item.Reason, item.Message)
+	}
+	fmt.Fprintf(&buf, "end event dump for %s/%s", podNamespace, podName)
+	return buf.String()
+}
+
+func GetEventsForPod(k8sCli kubernetes.Interface, ctx context.Context, podNamespace, podName string) ([]corev1.Event, error) {
+	klog.Infof("checking events for pod %s/%s", podNamespace, podName)
+	opts := metav1.ListOptions{
+		FieldSelector: fmt.Sprintf("involvedObject.name=%s", podName),
+		TypeMeta:      metav1.TypeMeta{Kind: "Pod"},
+	}
+	events, err := k8sCli.CoreV1().Events(podNamespace).List(ctx, opts)
+	if err != nil {
+		klog.ErrorS(err, "cannot get events for pod %s/%s", podNamespace, podName)
+		return nil, err
+	}
+	return events.Items, nil
+}

--- a/test/e2e/utils/pods/pods.go
+++ b/test/e2e/utils/pods/pods.go
@@ -24,12 +24,14 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/k8stopologyawareschedwg/deployer/pkg/clientutil"
 )
@@ -127,4 +129,19 @@ func GetByRegex(cs client.Client, reg string) ([]*corev1.Pod, error) {
 		}
 	}
 	return ret, nil
+}
+
+func GetByDeployment(cli client.Client, ctx context.Context, deployment appsv1.Deployment) ([]corev1.Pod, error) {
+	podList := &corev1.PodList{}
+	sel, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
+	if err != nil {
+		return nil, err
+	}
+
+	err = cli.List(ctx, podList, &client.ListOptions{Namespace: deployment.Namespace, LabelSelector: sel})
+	if err != nil {
+		return nil, err
+	}
+
+	return podList.Items, nil
 }


### PR DESCRIPTION
the scheduler is a control plane component, thus it should run by default on the control plane.

Fixes: #177 