### PR TITLE
pkg: trickle down defaults in pkgs

### DIFF
--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -32,15 +32,9 @@ import (
 	"github.com/k8stopologyawareschedwg/deployer/pkg/clientutil"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/sched"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/updaters"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/objectupdate"
-)
-
-// TODO: move elsewhere
-const (
-	DefaultSchedulerProfileName  = "topology-aware-scheduler"
-	DefaultSchedulerResyncPeriod = 0 * time.Second
-	DefaultUpdaterSyncPeriod     = 10 * time.Second
 )
 
 type CommonOptions struct {
@@ -119,11 +113,11 @@ func InitFlags(flags *pflag.FlagSet, commonOpts *CommonOptions) {
 	flags.BoolVar(&commonOpts.UpdaterPFPEnable, "updater-pfp-enable", true, "toggle PFP support on the updater side.")
 	flags.BoolVar(&commonOpts.UpdaterNotifEnable, "updater-notif-enable", true, "toggle event-based notification support on the updater side.")
 	flags.BoolVar(&commonOpts.UpdaterCRIHooksEnable, "updater-cri-hooks-enable", true, "toggle installation of CRI hooks on the updater side.")
-	flags.DurationVar(&commonOpts.UpdaterSyncPeriod, "updater-sync-period", DefaultUpdaterSyncPeriod, "tune the updater synchronization (nrt update) interval. Use 0 to disable.")
-	flags.IntVar(&commonOpts.UpdaterVerbose, "updater-verbose", 1, "set the updater verbosiness.")
-	flags.StringVar(&commonOpts.SchedProfileName, "sched-profile-name", DefaultSchedulerProfileName, "inject scheduler profile name.")
-	flags.DurationVar(&commonOpts.SchedResyncPeriod, "sched-resync-period", DefaultSchedulerResyncPeriod, "inject scheduler resync period.")
-	flags.IntVar(&commonOpts.SchedVerbose, "sched-verbose", 4, "set the scheduler verbosiness.")
+	flags.DurationVar(&commonOpts.UpdaterSyncPeriod, "updater-sync-period", updaters.DefaultSyncPeriod, "tune the updater synchronization (nrt update) interval. Use 0 to disable.")
+	flags.IntVar(&commonOpts.UpdaterVerbose, "updater-verbose", updaters.DefaultVerbose, "set the updater verbosiness.")
+	flags.StringVar(&commonOpts.SchedProfileName, "sched-profile-name", sched.DefaultProfileName, "inject scheduler profile name.")
+	flags.DurationVar(&commonOpts.SchedResyncPeriod, "sched-resync-period", sched.DefaultResyncPeriod, "inject scheduler resync period.")
+	flags.IntVar(&commonOpts.SchedVerbose, "sched-verbose", sched.DefaultVerbose, "set the scheduler verbosiness.")
 }
 
 func PostSetupOptions(commonOpts *CommonOptions) error {

--- a/pkg/deployer/sched/sched.go
+++ b/pkg/deployer/sched/sched.go
@@ -27,6 +27,12 @@ import (
 	schedmanifests "github.com/k8stopologyawareschedwg/deployer/pkg/manifests/sched"
 )
 
+const (
+	DefaultProfileName  = "topology-aware-scheduler"
+	DefaultResyncPeriod = 0 * time.Second
+	DefaultVerbose      = 4
+)
+
 type Options struct {
 	Platform          platform.Platform
 	WaitCompletion    bool

--- a/pkg/deployer/updaters/updaters.go
+++ b/pkg/deployer/updaters/updaters.go
@@ -19,6 +19,7 @@ package updaters
 import (
 	"context"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -27,6 +28,11 @@ import (
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/wait"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/manifests"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/objectupdate"
+)
+
+const (
+	DefaultSyncPeriod = 10 * time.Second
+	DefaultVerbose    = 1
 )
 
 const (

--- a/pkg/objectupdate/sched/sched_test.go
+++ b/pkg/objectupdate/sched/sched_test.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	pluginconfig "sigs.k8s.io/scheduler-plugins/apis/config"
 
+	depsched "github.com/k8stopologyawareschedwg/deployer/pkg/deployer/sched"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/manifests"
 )
 
@@ -72,7 +73,7 @@ func TestSchedulerDeployment(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:               "defaults",
-			verbose:            4, // TODO: this *IS* the default - see pkg/commands/root.go - but how do we keep this in sync?
+			verbose:            depsched.DefaultVerbose,
 			expectedRenderedDp: expectedSchedDeploymentDefault,
 		},
 		{


### PR DESCRIPTION
Move defaults closer to the sub-packages instead
of declaring them in the root command and just imply consistency all across the stack.

Now we have means to programmatically access them.