### PR TITLE
manifests: updater mount the directory, not the socket

### DIFF
--- a/pkg/manifests/yaml/nfd/topologyupdater/daemonset.yaml
+++ b/pkg/manifests/yaml/nfd/topologyupdater/daemonset.yaml
@@ -39,8 +39,8 @@ spec:
           volumeMounts:
             - mountPath: /host-var/lib/kubelet/config.yaml
               name: kubelet-podresources-conf
-            - mountPath: /host-var/lib/kubelet/pod-resources/kubelet.sock
-              name: kubelet-podresources-sock
+            - mountPath: /host-var/lib/kubelet/pod-resources
+              name: kubelet-podresources
             - mountPath: /host-sys
               name: host-sys
       dnsPolicy: ClusterFirstWithHostNet
@@ -53,5 +53,5 @@ spec:
             path: /var/lib/kubelet/config.yaml
           name: kubelet-podresources-conf
         - hostPath:
-            path: /var/lib/kubelet/pod-resources/kubelet.sock
-          name: kubelet-podresources-sock
+            path: /var/lib/kubelet/pod-resources
+          name: kubelet-podresources

--- a/pkg/manifests/yaml/rte/daemonset.yaml
+++ b/pkg/manifests/yaml/rte/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
         args:
         - --sleep-interval=10s
         - --sysfs=/host-sys
-        - --podresources-socket=unix:///host-podresources-socket/kubelet.sock
+        - --podresources-socket=unix:///host-podresources/kubelet.sock
         env:
         - name: NODE_NAME
           valueFrom:
@@ -45,8 +45,8 @@ spec:
           - name: host-sys
             mountPath: "/host-sys"
             readOnly: true
-          - name: host-podresources-socket
-            mountPath: "/host-podresources-socket/kubelet.sock"
+          - name: host-podresources
+            mountPath: "/host-podresources"
       - name: shared-pool-container
         image: gcr.io/google_containers/pause-amd64:3.0
       volumes:
@@ -54,7 +54,7 @@ spec:
         hostPath:
           path: "/sys"
           type: Directory
-      - name: host-podresources-socket
+      - name: host-podresources
         hostPath:
-          path: "/var/lib/kubelet/pod-resources/kubelet.sock"
-          type: Socket
+          path: "/var/lib/kubelet/pod-resources"
+          type: Directory

--- a/pkg/objectupdate/rte/rte.go
+++ b/pkg/objectupdate/rte/rte.go
@@ -39,12 +39,12 @@ const (
 )
 
 const (
-	rteNotifierVolumeName           = "host-run-rte"
-	rteSysVolumeName                = "host-sys"
-	rtePodresourcesSocketVolumeName = "host-podresources-socket"
-	rteKubeletDirVolumeName         = "host-var-lib-kubelet"
-	rteNotifierFileName             = "notify"
-	hostNotifierDir                 = "/run/rte"
+	rteNotifierVolumeName        = "host-run-rte"
+	rteSysVolumeName             = "host-sys"
+	rtePodresourcesDirVolumeName = "host-podresources"
+	rteKubeletDirVolumeName      = "host-var-lib-kubelet"
+	rteNotifierFileName          = "notify"
+	hostNotifierDir              = "/run/rte"
 )
 
 func ContainerConfig(podSpec *corev1.PodSpec, cnt *corev1.Container, configMapName string) {

--- a/pkg/objectupdate/rte/rte_test.go
+++ b/pkg/objectupdate/rte/rte_test.go
@@ -157,7 +157,6 @@ func TestDaemonSet(t *testing.T) {
 		expectedVolumeMounts map[string]string
 	}
 
-	containerPodResourcesSocket := fmt.Sprintf("/%s/kubelet.sock", rtePodresourcesSocketVolumeName)
 	containerHostSysDir := fmt.Sprintf("/%s", rteSysVolumeName)
 	testCases := []testCase{
 		{
@@ -165,18 +164,18 @@ func TestDaemonSet(t *testing.T) {
 			plat: platform.OpenShift,
 			expectedCommandArgs: []string{
 				fmt.Sprintf("--sysfs=%s", containerHostSysDir),
-				fmt.Sprintf("--podresources-socket=unix://%s", containerPodResourcesSocket),
+				fmt.Sprintf("--podresources-socket=unix:///%s/%s", rtePodresourcesDirVolumeName, "kubelet.sock"),
 				fmt.Sprintf("--notify-file=/%s/%s", rteNotifierVolumeName, rteNotifierFileName),
 			},
 			expectedVolumes: map[string]string{
-				rteSysVolumeName:                "/sys",
-				rtePodresourcesSocketVolumeName: "/var/lib/kubelet/pod-resources/kubelet.sock",
-				rteNotifierVolumeName:           "/run/rte",
+				rteSysVolumeName:             "/sys",
+				rtePodresourcesDirVolumeName: "/var/lib/kubelet/pod-resources",
+				rteNotifierVolumeName:        "/run/rte",
 			},
 			expectedVolumeMounts: map[string]string{
-				rteSysVolumeName:                containerHostSysDir,
-				rtePodresourcesSocketVolumeName: containerPodResourcesSocket,
-				rteNotifierVolumeName:           fmt.Sprintf("/%s", rteNotifierVolumeName),
+				rteSysVolumeName:             containerHostSysDir,
+				rtePodresourcesDirVolumeName: fmt.Sprintf("/%s", rtePodresourcesDirVolumeName),
+				rteNotifierVolumeName:        fmt.Sprintf("/%s", rteNotifierVolumeName),
 			},
 		},
 		{
@@ -184,22 +183,22 @@ func TestDaemonSet(t *testing.T) {
 			plat: platform.Kubernetes,
 			expectedCommandArgs: []string{
 				fmt.Sprintf("--sysfs=%s", containerHostSysDir),
-				fmt.Sprintf("--podresources-socket=unix://%s", containerPodResourcesSocket),
+				fmt.Sprintf("--podresources-socket=unix:///%s/%s", rtePodresourcesDirVolumeName, "kubelet.sock"),
 				fmt.Sprintf("--kubelet-config-file=/%s/config.yaml", rteKubeletDirVolumeName),
 				fmt.Sprintf("--kubelet-state-dir=/%s", rteKubeletDirVolumeName),
 				fmt.Sprintf("--notify-file=/%s/%s", rteNotifierVolumeName, rteNotifierFileName),
 			},
 			expectedVolumes: map[string]string{
-				rteSysVolumeName:                "/sys",
-				rtePodresourcesSocketVolumeName: "/var/lib/kubelet/pod-resources/kubelet.sock",
-				rteKubeletDirVolumeName:         "/var/lib/kubelet",
-				rteNotifierVolumeName:           "/run/rte",
+				rteSysVolumeName:             "/sys",
+				rtePodresourcesDirVolumeName: "/var/lib/kubelet/pod-resources",
+				rteKubeletDirVolumeName:      "/var/lib/kubelet",
+				rteNotifierVolumeName:        "/run/rte",
 			},
 			expectedVolumeMounts: map[string]string{
-				rteSysVolumeName:                containerHostSysDir,
-				rtePodresourcesSocketVolumeName: containerPodResourcesSocket,
-				rteKubeletDirVolumeName:         fmt.Sprintf("/%s", rteKubeletDirVolumeName),
-				rteNotifierVolumeName:           fmt.Sprintf("/%s", rteNotifierVolumeName),
+				rteSysVolumeName:             containerHostSysDir,
+				rtePodresourcesDirVolumeName: fmt.Sprintf("/%s", rtePodresourcesDirVolumeName),
+				rteKubeletDirVolumeName:      fmt.Sprintf("/%s", rteKubeletDirVolumeName),
+				rteNotifierVolumeName:        fmt.Sprintf("/%s", rteNotifierVolumeName),
 			},
 		},
 	}


### PR DESCRIPTION
Quoting kube docs:

```
when accessing the `/var/lib/kubelet/pod-resources/kubelet.sock` from DaemonSet
or any other app deployed as a container on the host, which is mounting socket as
a volume, it is a good practice to mount directory `/var/lib/kubelet/pod-resources/`
instead of the `/var/lib/kubelet/pod-resources/kubelet.sock`. This will ensure
that after kubelet restart, container will be able to re-connect to this socket.

Container mounts are managed by inode referencing the socket or directory,
depending on what was mounted. When kubelet restarts, socket is deleted
and a new socket is created, while directory stays untouched.
So the original inode for the socket become unusable. Inode to directory
will continue working.
```