### PR TITLE
wait: consolidate command line wait path

### DIFF
--- a/pkg/deployer/deployer.go
+++ b/pkg/deployer/deployer.go
@@ -24,11 +24,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type WaitableObject struct {
-	Obj  client.Object
-	Wait func(ctx context.Context) error
-}
-
 type Environment struct {
 	Ctx context.Context
 	Cli client.Client

--- a/pkg/deployer/sched/sched.go
+++ b/pkg/deployer/sched/sched.go
@@ -25,6 +25,7 @@ import (
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
 	schedmanifests "github.com/k8stopologyawareschedwg/deployer/pkg/manifests/sched"
+	schedwait "github.com/k8stopologyawareschedwg/deployer/pkg/objectwait/sched"
 )
 
 type Options struct {
@@ -64,7 +65,7 @@ func Deploy(env *deployer.Environment, opts Options) error {
 	}
 	env.Log.V(3).Info("manifests loaded")
 
-	for _, wo := range mf.ToCreatableObjects(env.Cli, env.Log) {
+	for _, wo := range schedwait.Creatable(mf, env.Cli, env.Log) {
 		if err := env.CreateObject(wo.Obj); err != nil {
 			return err
 		}
@@ -102,7 +103,7 @@ func Remove(env *deployer.Environment, opts Options) error {
 	}
 	env.Log.V(3).Info("manifests loaded")
 
-	for _, wo := range mf.ToDeletableObjects(env.Cli, env.Log) {
+	for _, wo := range schedwait.Deletable(mf, env.Cli, env.Log) {
 		err = env.DeleteObject(wo.Obj)
 		if err != nil {
 			continue

--- a/pkg/deployer/updaters/objects.go
+++ b/pkg/deployer/updaters/objects.go
@@ -24,6 +24,9 @@ import (
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer"
 	nfdmanifests "github.com/k8stopologyawareschedwg/deployer/pkg/manifests/nfd"
 	rtemanifests "github.com/k8stopologyawareschedwg/deployer/pkg/manifests/rte"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/objectwait"
+	nfdwait "github.com/k8stopologyawareschedwg/deployer/pkg/objectwait/nfd"
+	rtewait "github.com/k8stopologyawareschedwg/deployer/pkg/objectwait/rte"
 )
 
 func GetObjects(opts Options, updaterType, namespace string) ([]client.Object, error) {
@@ -53,7 +56,7 @@ func GetObjects(opts Options, updaterType, namespace string) ([]client.Object, e
 	return nil, fmt.Errorf("unsupported updater: %q", updaterType)
 }
 
-func getCreatableObjects(env *deployer.Environment, opts Options, updaterType, namespace string) ([]deployer.WaitableObject, error) {
+func getCreatableObjects(env *deployer.Environment, opts Options, updaterType, namespace string) ([]objectwait.WaitableObject, error) {
 	if updaterType == RTE {
 		mf, err := rtemanifests.GetManifests(opts.Platform, opts.PlatformVersion, namespace, opts.EnableCRIHooks)
 		if err != nil {
@@ -63,7 +66,7 @@ func getCreatableObjects(env *deployer.Environment, opts Options, updaterType, n
 		if err != nil {
 			return nil, err
 		}
-		return ret.ToCreatableObjects(env.Cli, env.Log), nil
+		return rtewait.Creatable(ret, env.Cli, env.Log), nil
 	}
 	if updaterType == NFD {
 		mf, err := nfdmanifests.GetManifests(opts.Platform, namespace)
@@ -74,12 +77,12 @@ func getCreatableObjects(env *deployer.Environment, opts Options, updaterType, n
 		if err != nil {
 			return nil, err
 		}
-		return ret.ToCreatableObjects(env.Cli, env.Log), nil
+		return nfdwait.Creatable(ret, env.Cli, env.Log), nil
 	}
 	return nil, fmt.Errorf("unsupported updater: %q", updaterType)
 }
 
-func getDeletableObjects(env *deployer.Environment, opts Options, updaterType, namespace string) ([]deployer.WaitableObject, error) {
+func getDeletableObjects(env *deployer.Environment, opts Options, updaterType, namespace string) ([]objectwait.WaitableObject, error) {
 	if updaterType == RTE {
 		mf, err := rtemanifests.GetManifests(opts.Platform, opts.PlatformVersion, namespace, opts.EnableCRIHooks)
 		if err != nil {
@@ -89,7 +92,7 @@ func getDeletableObjects(env *deployer.Environment, opts Options, updaterType, n
 		if err != nil {
 			return nil, err
 		}
-		return ret.ToDeletableObjects(env.Cli, env.Log), nil
+		return rtewait.Deletable(ret, env.Cli, env.Log), nil
 	}
 	if updaterType == NFD {
 		mf, err := nfdmanifests.GetManifests(opts.Platform, namespace)
@@ -100,7 +103,7 @@ func getDeletableObjects(env *deployer.Environment, opts Options, updaterType, n
 		if err != nil {
 			return nil, err
 		}
-		return ret.ToDeletableObjects(env.Cli, env.Log), nil
+		return nfdwait.Deletable(ret, env.Cli, env.Log), nil
 	}
 	return nil, fmt.Errorf("unsupported updater: %q", updaterType)
 }

--- a/pkg/deployer/updaters/updaters.go
+++ b/pkg/deployer/updaters/updaters.go
@@ -27,6 +27,7 @@ import (
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/wait"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/manifests"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/objectupdate"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/objectwait"
 )
 
 const (
@@ -59,7 +60,7 @@ func Deploy(env *deployer.Environment, updaterType string, opts Options) error {
 
 	env.Log.V(3).Info("manifests loaded")
 
-	objs = append([]deployer.WaitableObject{{Obj: ns}}, objs...)
+	objs = append([]objectwait.WaitableObject{{Obj: ns}}, objs...)
 
 	for _, wo := range objs {
 		if err := env.CreateObject(wo.Obj); err != nil {
@@ -95,7 +96,7 @@ func Remove(env *deployer.Environment, updaterType string, opts Options) error {
 
 	env.Log.V(3).Info("%s manifests loaded")
 
-	objs = append(objs, deployer.WaitableObject{
+	objs = append(objs, objectwait.WaitableObject{
 		Obj:  ns,
 		Wait: func(ctx context.Context) error { return wait.With(env.Cli, env.Log).ForNamespaceDeleted(ctx, ns.Name) },
 	})

--- a/pkg/deployer/wait/wait.go
+++ b/pkg/deployer/wait/wait.go
@@ -38,6 +38,16 @@ const (
 	DefaultPollTimeout  = 2 * time.Minute
 )
 
+var (
+	basePollInterval = DefaultPollInterval
+	basePollTimeout  = DefaultPollTimeout
+)
+
+func SetBaseValues(interval, timeout time.Duration) {
+	basePollInterval = interval
+	basePollTimeout = timeout
+}
+
 type ObjectKey struct {
 	Namespace string
 	Name      string
@@ -69,9 +79,13 @@ func With(cli client.Client, log logr.Logger) *Waiter {
 	return &Waiter{
 		Cli:          cli,
 		Log:          log,
-		PollTimeout:  DefaultPollTimeout,
-		PollInterval: DefaultPollInterval,
+		PollTimeout:  basePollTimeout,
+		PollInterval: basePollInterval,
 	}
+}
+
+func (wt *Waiter) String() string {
+	return fmt.Sprintf("wait every %v up to %v", wt.PollInterval, wt.PollTimeout)
 }
 
 func (wt *Waiter) Timeout(tt time.Duration) *Waiter {

--- a/pkg/manifests/api/api.go
+++ b/pkg/manifests/api/api.go
@@ -17,13 +17,10 @@
 package api
 
 import (
-	"github.com/go-logr/logr"
-
 	apiextensionv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/manifests"
 )
@@ -37,18 +34,6 @@ type Manifests struct {
 func (mf Manifests) ToObjects() []client.Object {
 	return []client.Object{
 		mf.Crd,
-	}
-}
-
-func (mf Manifests) ToCreatableObjects(cli client.Client, log logr.Logger) []deployer.WaitableObject {
-	return []deployer.WaitableObject{
-		{Obj: mf.Crd},
-	}
-}
-
-func (mf Manifests) ToDeletableObjects(cli client.Client, log logr.Logger) []deployer.WaitableObject {
-	return []deployer.WaitableObject{
-		{Obj: mf.Crd},
 	}
 }
 

--- a/pkg/manifests/nfd/nfd.go
+++ b/pkg/manifests/nfd/nfd.go
@@ -17,18 +17,12 @@
 package nfd
 
 import (
-	"context"
-
-	"github.com/go-logr/logr"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
-	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/wait"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/manifests"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/objectupdate"
 	nfdupdate "github.com/k8stopologyawareschedwg/deployer/pkg/objectupdate/nfd"
@@ -92,28 +86,6 @@ func (mf Manifests) ToObjects() []client.Object {
 		mf.CRTopologyUpdater,
 		mf.CRBTopologyUpdater,
 		mf.DSTopologyUpdater,
-	}
-}
-
-func (mf Manifests) ToCreatableObjects(cli client.Client, log logr.Logger) []deployer.WaitableObject {
-	return []deployer.WaitableObject{
-		{Obj: mf.SATopologyUpdater},
-		{Obj: mf.CRTopologyUpdater},
-		{Obj: mf.CRBTopologyUpdater},
-		{
-			Obj: mf.DSTopologyUpdater,
-			Wait: func(ctx context.Context) error {
-				_, err := wait.With(cli, log).ForDaemonSetReady(ctx, mf.DSTopologyUpdater)
-				return err
-			},
-		},
-	}
-}
-
-func (mf Manifests) ToDeletableObjects(cli client.Client, log logr.Logger) []deployer.WaitableObject {
-	return []deployer.WaitableObject{
-		{Obj: mf.CRBTopologyUpdater},
-		{Obj: mf.CRTopologyUpdater},
 	}
 }
 

--- a/pkg/manifests/rte/rte.go
+++ b/pkg/manifests/rte/rte.go
@@ -17,10 +17,6 @@
 package rte
 
 import (
-	"context"
-
-	"github.com/go-logr/logr"
-
 	securityv1 "github.com/openshift/api/security/v1"
 	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -29,9 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
-	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/wait"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/manifests"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/objectupdate"
 	ocpupdate "github.com/k8stopologyawareschedwg/deployer/pkg/objectupdate/ocp"
@@ -184,79 +178,6 @@ func (mf Manifests) ToObjects() []client.Object {
 		mf.DaemonSet,
 		mf.ServiceAccount,
 	)
-}
-
-func (mf Manifests) ToCreatableObjects(cli client.Client, log logr.Logger) []deployer.WaitableObject {
-	var objs []deployer.WaitableObject
-	if mf.ConfigMap != nil {
-		objs = append(objs, deployer.WaitableObject{
-			Obj: mf.ConfigMap,
-		})
-	}
-
-	if mf.SecurityContextConstraint != nil {
-		objs = append(objs, deployer.WaitableObject{
-			Obj: mf.SecurityContextConstraint,
-		})
-	}
-
-	if mf.MachineConfig != nil {
-		// TODO: we should add functionality to wait for the MCP update
-		objs = append(objs, deployer.WaitableObject{
-			Obj: mf.MachineConfig,
-		})
-	}
-
-	key := wait.ObjectKey{
-		Namespace: mf.DaemonSet.Namespace,
-		Name:      mf.DaemonSet.Name,
-	}
-
-	return append(objs,
-		deployer.WaitableObject{Obj: mf.Role},
-		deployer.WaitableObject{Obj: mf.RoleBinding},
-		deployer.WaitableObject{Obj: mf.ClusterRole},
-		deployer.WaitableObject{Obj: mf.ClusterRoleBinding},
-		deployer.WaitableObject{Obj: mf.ServiceAccount},
-		deployer.WaitableObject{
-			Obj: mf.DaemonSet,
-			Wait: func(ctx context.Context) error {
-				_, err := wait.With(cli, log).ForDaemonSetReadyByKey(ctx, key)
-				return err
-			},
-		},
-	)
-}
-
-func (mf Manifests) ToDeletableObjects(cli client.Client, log logr.Logger) []deployer.WaitableObject {
-	objs := []deployer.WaitableObject{
-		{
-			Obj: mf.DaemonSet,
-			Wait: func(ctx context.Context) error {
-				return wait.With(cli, log).ForDaemonSetDeleted(ctx, mf.DaemonSet.Namespace, mf.DaemonSet.Name)
-			},
-		},
-		{Obj: mf.Role},
-		{Obj: mf.RoleBinding},
-		{Obj: mf.ClusterRole},
-		{Obj: mf.ClusterRoleBinding},
-		{Obj: mf.ServiceAccount},
-	}
-	if mf.ConfigMap != nil {
-		objs = append(objs, deployer.WaitableObject{Obj: mf.ConfigMap})
-	}
-	if mf.SecurityContextConstraint != nil {
-		objs = append(objs, deployer.WaitableObject{
-			Obj: mf.SecurityContextConstraint,
-		})
-	}
-	if mf.MachineConfig != nil {
-		objs = append(objs, deployer.WaitableObject{
-			// TODO: we should add functionality to wait for the MCP update
-			Obj: mf.MachineConfig,
-		})
-	}
-	return objs
 }
 
 func New(plat platform.Platform) Manifests {

--- a/pkg/objectwait/api/api.go
+++ b/pkg/objectwait/api/api.go
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ */
+
+package api
+
+import (
+	"github.com/go-logr/logr"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	apimf "github.com/k8stopologyawareschedwg/deployer/pkg/manifests/api"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/objectwait"
+)
+
+func Creatable(mf apimf.Manifests, cli client.Client, log logr.Logger) []objectwait.WaitableObject {
+	return []objectwait.WaitableObject{
+		{Obj: mf.Crd},
+	}
+}
+
+func Deletable(mf apimf.Manifests, cli client.Client, log logr.Logger) []objectwait.WaitableObject {
+	return []objectwait.WaitableObject{
+		{Obj: mf.Crd},
+	}
+}

--- a/pkg/objectwait/nfd/nfd.go
+++ b/pkg/objectwait/nfd/nfd.go
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ */
+
+package nfd
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/wait"
+	nfdmf "github.com/k8stopologyawareschedwg/deployer/pkg/manifests/nfd"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/objectwait"
+)
+
+func Creatable(mf nfdmf.Manifests, cli client.Client, log logr.Logger) []objectwait.WaitableObject {
+	return []objectwait.WaitableObject{
+		{Obj: mf.SATopologyUpdater},
+		{Obj: mf.CRTopologyUpdater},
+		{Obj: mf.CRBTopologyUpdater},
+		{
+			Obj: mf.DSTopologyUpdater,
+			Wait: func(ctx context.Context) error {
+				_, err := wait.With(cli, log).ForDaemonSetReady(ctx, mf.DSTopologyUpdater)
+				return err
+			},
+		},
+	}
+}
+
+func Deletable(mf nfdmf.Manifests, cli client.Client, log logr.Logger) []objectwait.WaitableObject {
+	return []objectwait.WaitableObject{
+		{Obj: mf.CRBTopologyUpdater},
+		{Obj: mf.CRTopologyUpdater},
+	}
+}

--- a/pkg/objectwait/rte/rte.go
+++ b/pkg/objectwait/rte/rte.go
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ */
+
+package rte
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/wait"
+	rtemf "github.com/k8stopologyawareschedwg/deployer/pkg/manifests/rte"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/objectwait"
+)
+
+func Creatable(mf rtemf.Manifests, cli client.Client, log logr.Logger) []objectwait.WaitableObject {
+	var objs []objectwait.WaitableObject
+	if mf.ConfigMap != nil {
+		objs = append(objs, objectwait.WaitableObject{
+			Obj: mf.ConfigMap,
+		})
+	}
+
+	if mf.SecurityContextConstraint != nil {
+		objs = append(objs, objectwait.WaitableObject{
+			Obj: mf.SecurityContextConstraint,
+		})
+	}
+
+	if mf.MachineConfig != nil {
+		// TODO: we should add functionality to wait for the MCP update
+		objs = append(objs, objectwait.WaitableObject{
+			Obj: mf.MachineConfig,
+		})
+	}
+
+	key := wait.ObjectKey{
+		Namespace: mf.DaemonSet.Namespace,
+		Name:      mf.DaemonSet.Name,
+	}
+
+	return append(objs,
+		objectwait.WaitableObject{Obj: mf.Role},
+		objectwait.WaitableObject{Obj: mf.RoleBinding},
+		objectwait.WaitableObject{Obj: mf.ClusterRole},
+		objectwait.WaitableObject{Obj: mf.ClusterRoleBinding},
+		objectwait.WaitableObject{Obj: mf.ServiceAccount},
+		objectwait.WaitableObject{
+			Obj: mf.DaemonSet,
+			Wait: func(ctx context.Context) error {
+				_, err := wait.With(cli, log).ForDaemonSetReadyByKey(ctx, key)
+				return err
+			},
+		},
+	)
+}
+
+func Deletable(mf rtemf.Manifests, cli client.Client, log logr.Logger) []objectwait.WaitableObject {
+	objs := []objectwait.WaitableObject{
+		{
+			Obj: mf.DaemonSet,
+			Wait: func(ctx context.Context) error {
+				return wait.With(cli, log).ForDaemonSetDeleted(ctx, mf.DaemonSet.Namespace, mf.DaemonSet.Name)
+			},
+		},
+		{Obj: mf.Role},
+		{Obj: mf.RoleBinding},
+		{Obj: mf.ClusterRole},
+		{Obj: mf.ClusterRoleBinding},
+		{Obj: mf.ServiceAccount},
+	}
+	if mf.ConfigMap != nil {
+		objs = append(objs, objectwait.WaitableObject{Obj: mf.ConfigMap})
+	}
+	if mf.SecurityContextConstraint != nil {
+		objs = append(objs, objectwait.WaitableObject{
+			Obj: mf.SecurityContextConstraint,
+		})
+	}
+	if mf.MachineConfig != nil {
+		objs = append(objs, objectwait.WaitableObject{
+			// TODO: we should add functionality to wait for the MCP update
+			Obj: mf.MachineConfig,
+		})
+	}
+	return objs
+}

--- a/pkg/objectwait/sched/sched.go
+++ b/pkg/objectwait/sched/sched.go
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ */
+
+package sched
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/wait"
+	schedmf "github.com/k8stopologyawareschedwg/deployer/pkg/manifests/sched"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/objectwait"
+)
+
+func Creatable(mf schedmf.Manifests, cli client.Client, log logr.Logger) []objectwait.WaitableObject {
+	return []objectwait.WaitableObject{
+		{Obj: mf.Crd},
+		{Obj: mf.Namespace},
+		{Obj: mf.SAScheduler},
+		{Obj: mf.CRScheduler},
+		{Obj: mf.CRBScheduler},
+		{Obj: mf.RBScheduler},
+		{Obj: mf.ConfigMap},
+		{
+			Obj: mf.DPScheduler,
+			Wait: func(ctx context.Context) error {
+				_, err := wait.With(cli, log).ForDeploymentComplete(ctx, mf.DPScheduler)
+				return err
+			},
+		},
+		{Obj: mf.SAController},
+		{Obj: mf.CRController},
+		{Obj: mf.CRBController},
+		{Obj: mf.RBController},
+		{
+			Obj: mf.DPController,
+			Wait: func(ctx context.Context) error {
+				_, err := wait.With(cli, log).ForDeploymentComplete(ctx, mf.DPController)
+				return err
+			},
+		},
+	}
+}
+
+func Deletable(mf schedmf.Manifests, cli client.Client, log logr.Logger) []objectwait.WaitableObject {
+	return []objectwait.WaitableObject{
+		{
+			Obj: mf.Namespace,
+			Wait: func(ctx context.Context) error {
+				return wait.With(cli, log).ForNamespaceDeleted(ctx, mf.Namespace.Name)
+			},
+		},
+		// no need to remove objects created inside the namespace we just removed
+		{Obj: mf.CRBScheduler},
+		{Obj: mf.CRScheduler},
+		{Obj: mf.RBScheduler},
+		{Obj: mf.CRBController},
+		{Obj: mf.CRController},
+		{Obj: mf.RBController},
+		{Obj: mf.Crd},
+	}
+}

--- a/pkg/objectwait/waitable.go
+++ b/pkg/objectwait/waitable.go
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ */
+
+package objectwait
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type WaitableObject struct {
+	Obj  client.Object
+	Wait func(ctx context.Context) error
+}


### PR DESCRIPTION
commandline UX improvement for waitable objects: enable to set base (global) values.
Since this code is used only in command flow (e.g. not really needed by library code), start isolating it in their own source code files, until a more comprehensive reorganization happens.

Fixes: #201 