### PR TITLE
[manual][release-0.14] ghactions: pin images to ubuntu 22.04

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,7 +11,7 @@ defaults:
 
 jobs:
   e2e-positive:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: checkout sources
       uses: actions/checkout@v3
@@ -49,7 +49,7 @@ jobs:
         _out/e2e.test -ginkgo.focus='\[PositiveFlow\]' -ginkgo.v
 
   e2e-negative:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: checkout sources
       uses: actions/checkout@v3

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ defaults:
 
 jobs:
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: checkout sources
       uses: actions/checkout@v3


### PR DESCRIPTION
Let's update to the latest LTS from the ancient 20.04, and also let's take the chance to pin the version explicitely rather than rely to floating tags.