### PR TITLE
statedir: forcefully disable

### DIFF
--- a/pkg/objectupdate/nfd/nfd.go
+++ b/pkg/objectupdate/nfd/nfd.go
@@ -45,6 +45,10 @@ func UpdaterDaemonSet(ds *appsv1.DaemonSet, opts objectupdate.DaemonSetOptions) 
 		if opts.PFPEnable {
 			flags.SetToggle("--pods-fingerprint")
 		}
+
+		// we need to explicitely disable the kubelet state dir monitoring, which is opt-out
+		flags.SetOption("--kubelet-state-dir", "")
+
 		c.Args = flags.Argv()
 
 		c.Image = images.NodeFeatureDiscoveryImage

--- a/pkg/objectupdate/rte/rte.go
+++ b/pkg/objectupdate/rte/rte.go
@@ -138,9 +138,6 @@ func DaemonSet(ds *appsv1.DaemonSet, plat platform.Platform, configMapName strin
 		}
 		if plat == platform.Kubernetes {
 			flags.SetOption("--kubelet-config-file", fmt.Sprintf("/%s/config.yaml", rteKubeletDirVolumeName))
-			if opts.NotificationEnable {
-				flags.SetOption("--kubelet-state-dir", fmt.Sprintf("/%s", rteKubeletDirVolumeName))
-			}
 		}
 		cntSpec.Args = flags.Argv()
 

--- a/pkg/objectupdate/rte/rte_test.go
+++ b/pkg/objectupdate/rte/rte_test.go
@@ -185,7 +185,6 @@ func TestDaemonSet(t *testing.T) {
 				fmt.Sprintf("--sysfs=%s", containerHostSysDir),
 				fmt.Sprintf("--podresources-socket=unix:///%s/%s", rtePodresourcesDirVolumeName, "kubelet.sock"),
 				fmt.Sprintf("--kubelet-config-file=/%s/config.yaml", rteKubeletDirVolumeName),
-				fmt.Sprintf("--kubelet-state-dir=/%s", rteKubeletDirVolumeName),
 				fmt.Sprintf("--notify-file=/%s/%s", rteNotifierVolumeName, rteNotifierFileName),
 			},
 			expectedVolumes: map[string]string{


### PR DESCRIPTION
The kubelet state dir monitoring is hard to secure and has limitations (cannot react timely to deletions).
The preferred approach is to use OCI hooks and notification file.
So we unconditionally disable on NFD and stop enabling it on RTE.