### PR TITLE
more logic removal from commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ Flags:
   -h, --help   help for render
 
 Global Flags:
-  -D, --debug                    enable debug log
   -P, --platform string          platform to deploy on
       --pull-if-not-present      force pull policies to IfNotPresent.
   -R, --replicas int             set the replica value - where relevant. (default 1)

--- a/cmd/deployer/main.go
+++ b/cmd/deployer/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/k8stopologyawareschedwg/deployer/pkg/commands"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deploy"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer"
 	deployerversion "github.com/k8stopologyawareschedwg/deployer/pkg/version"
 )
@@ -32,7 +33,7 @@ type versionOptions struct {
 	hashOnly   bool
 }
 
-func NewVersionCommand(env *deployer.Environment, commonOpts *commands.CommonOptions) *cobra.Command {
+func NewVersionCommand(env *deployer.Environment, commonOpts *deploy.Options) *cobra.Command {
 	opts := versionOptions{}
 	version := &cobra.Command{
 		Use:   "version",

--- a/cmd/deployer/main.go
+++ b/cmd/deployer/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/k8stopologyawareschedwg/deployer/pkg/commands"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer"
 	deployerversion "github.com/k8stopologyawareschedwg/deployer/pkg/version"
 )
 
@@ -31,7 +32,7 @@ type versionOptions struct {
 	hashOnly   bool
 }
 
-func NewVersionCommand(commonOpts *commands.CommonOptions) *cobra.Command {
+func NewVersionCommand(env *deployer.Environment, commonOpts *commands.CommonOptions) *cobra.Command {
 	opts := versionOptions{}
 	version := &cobra.Command{
 		Use:   "version",

--- a/pkg/commands/deploy.go
+++ b/pkg/commands/deploy.go
@@ -75,7 +75,7 @@ func NewRemoveCommand(commonOpts *CommonOptions) *cobra.Command {
 			if opts.clusterVersion == platform.MissingVersion {
 				return fmt.Errorf("cannot autodetect the platform version, and no version given")
 			}
-			commonOpts.DebugLog.Info("detection", "platform", opts.clusterPlatform, "reason", reason, "version", opts.clusterVersion, "source", source)
+			commonOpts.Log.Info("detection", "platform", opts.clusterPlatform, "reason", reason, "version", opts.clusterVersion, "source", source)
 
 			err = sched.Remove(env, sched.Options{
 				Platform:          opts.clusterPlatform,
@@ -143,7 +143,7 @@ func NewDeployAPICommand(commonOpts *CommonOptions, opts *DeployOptions) *cobra.
 				return fmt.Errorf("cannot autodetect the platform version, and no version given")
 			}
 
-			commonOpts.DebugLog.Info("detection", "platform", opts.clusterPlatform, "reason", reason, "version", opts.clusterVersion, "source", source)
+			commonOpts.Log.Info("detection", "platform", opts.clusterPlatform, "reason", reason, "version", opts.clusterVersion, "source", source)
 			if err := api.Deploy(env, api.Options{Platform: opts.clusterPlatform}); err != nil {
 				return err
 			}
@@ -177,7 +177,7 @@ func NewDeploySchedulerPluginCommand(commonOpts *CommonOptions, opts *DeployOpti
 				return fmt.Errorf("cannot autodetect the platform version, and no version given")
 			}
 
-			commonOpts.DebugLog.Info("detection", "platform", opts.clusterPlatform, "reason", reason, "version", opts.clusterVersion, "source", source)
+			commonOpts.Log.Info("detection", "platform", opts.clusterPlatform, "reason", reason, "version", opts.clusterVersion, "source", source)
 			return sched.Deploy(env, sched.Options{
 				Platform:          opts.clusterPlatform,
 				WaitCompletion:    opts.waitCompletion,
@@ -217,7 +217,7 @@ func NewDeployTopologyUpdaterCommand(commonOpts *CommonOptions, opts *DeployOpti
 				return fmt.Errorf("cannot autodetect the platform version, and no version given")
 			}
 
-			commonOpts.DebugLog.Info("detection", "platform", opts.clusterPlatform, "reason", reason, "version", opts.clusterVersion, "source", source)
+			commonOpts.Log.Info("detection", "platform", opts.clusterPlatform, "reason", reason, "version", opts.clusterVersion, "source", source)
 			return updaters.Deploy(env, commonOpts.UpdaterType, updaters.Options{
 				Platform:        opts.clusterPlatform,
 				PlatformVersion: opts.clusterVersion,
@@ -255,7 +255,7 @@ func NewRemoveAPICommand(commonOpts *CommonOptions, opts *DeployOptions) *cobra.
 				return fmt.Errorf("cannot autodetect the platform version, and no version given")
 			}
 
-			commonOpts.DebugLog.Info("detection", "platform", opts.clusterPlatform, "reason", reason, "version", opts.clusterVersion, "source", source)
+			commonOpts.Log.Info("detection", "platform", opts.clusterPlatform, "reason", reason, "version", opts.clusterVersion, "source", source)
 			if err := api.Remove(env, api.Options{Platform: opts.clusterPlatform}); err != nil {
 				return err
 			}
@@ -289,7 +289,7 @@ func NewRemoveSchedulerPluginCommand(commonOpts *CommonOptions, opts *DeployOpti
 				return fmt.Errorf("cannot autodetect the platform version, and no version given")
 			}
 
-			commonOpts.DebugLog.Info("detection", "platform", opts.clusterPlatform, "reason", reason, "version", opts.clusterVersion, "source", source)
+			commonOpts.Log.Info("detection", "platform", opts.clusterPlatform, "reason", reason, "version", opts.clusterVersion, "source", source)
 			return sched.Remove(env, sched.Options{
 				Platform:          opts.clusterPlatform,
 				WaitCompletion:    opts.waitCompletion,
@@ -329,7 +329,7 @@ func NewRemoveTopologyUpdaterCommand(commonOpts *CommonOptions, opts *DeployOpti
 				return fmt.Errorf("cannot autodetect the platform version, and no version given")
 			}
 
-			commonOpts.DebugLog.Info("detection", "platform", opts.clusterPlatform, "reason", reason, "version", opts.clusterVersion, "source", source)
+			commonOpts.Log.Info("detection", "platform", opts.clusterPlatform, "reason", reason, "version", opts.clusterVersion, "source", source)
 			return updaters.Remove(env, commonOpts.UpdaterType, updaters.Options{
 				Platform:        opts.clusterPlatform,
 				PlatformVersion: opts.clusterVersion,
@@ -363,7 +363,7 @@ func deployOnCluster(commonOpts *CommonOptions, opts *DeployOptions) error {
 		return fmt.Errorf("cannot autodetect the platform version, and no version given")
 	}
 
-	commonOpts.DebugLog.Info("detection", "platform", opts.clusterPlatform, "reason", reason, "version", opts.clusterVersion, "source", source)
+	commonOpts.Log.Info("detection", "platform", opts.clusterPlatform, "reason", reason, "version", opts.clusterVersion, "source", source)
 	if err := api.Deploy(env, api.Options{
 		Platform: opts.clusterPlatform,
 	}); err != nil {

--- a/pkg/commands/deploy.go
+++ b/pkg/commands/deploy.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deploy"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/api"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
@@ -35,7 +36,7 @@ type DeployOptions struct {
 	waitCompletion  bool
 }
 
-func NewDeployCommand(env *deployer.Environment, commonOpts *CommonOptions) *cobra.Command {
+func NewDeployCommand(env *deployer.Environment, commonOpts *deploy.Options) *cobra.Command {
 	opts := &DeployOptions{}
 	deploy := &cobra.Command{
 		Use:   "deploy",
@@ -52,7 +53,7 @@ func NewDeployCommand(env *deployer.Environment, commonOpts *CommonOptions) *cob
 	return deploy
 }
 
-func NewRemoveCommand(env *deployer.Environment, commonOpts *CommonOptions) *cobra.Command {
+func NewRemoveCommand(env *deployer.Environment, commonOpts *deploy.Options) *cobra.Command {
 	opts := &DeployOptions{}
 	remove := &cobra.Command{
 		Use:   "remove",
@@ -94,7 +95,7 @@ func NewRemoveCommand(env *deployer.Environment, commonOpts *CommonOptions) *cob
 				PlatformVersion: opts.clusterVersion,
 				WaitCompletion:  opts.waitCompletion,
 				RTEConfigData:   commonOpts.RTEConfigData,
-				DaemonSet:       daemonSetOptionsFromCommonOptions(commonOpts),
+				DaemonSet:       daemonSetOptionsFrom(commonOpts),
 				EnableCRIHooks:  commonOpts.UpdaterCRIHooksEnable,
 			})
 			if err != nil {
@@ -119,7 +120,7 @@ func NewRemoveCommand(env *deployer.Environment, commonOpts *CommonOptions) *cob
 	return remove
 }
 
-func NewDeployAPICommand(env *deployer.Environment, commonOpts *CommonOptions, opts *DeployOptions) *cobra.Command {
+func NewDeployAPICommand(env *deployer.Environment, commonOpts *deploy.Options, opts *DeployOptions) *cobra.Command {
 	deploy := &cobra.Command{
 		Use:   "api",
 		Short: "deploy the APIs needed for topology-aware-scheduling",
@@ -150,7 +151,7 @@ func NewDeployAPICommand(env *deployer.Environment, commonOpts *CommonOptions, o
 	return deploy
 }
 
-func NewDeploySchedulerPluginCommand(env *deployer.Environment, commonOpts *CommonOptions, opts *DeployOptions) *cobra.Command {
+func NewDeploySchedulerPluginCommand(env *deployer.Environment, commonOpts *deploy.Options, opts *DeployOptions) *cobra.Command {
 	deploy := &cobra.Command{
 		Use:   "scheduler-plugin",
 		Short: "deploy the scheduler plugin needed for topology-aware-scheduling",
@@ -189,7 +190,7 @@ func NewDeploySchedulerPluginCommand(env *deployer.Environment, commonOpts *Comm
 	return deploy
 }
 
-func NewDeployTopologyUpdaterCommand(env *deployer.Environment, commonOpts *CommonOptions, opts *DeployOptions) *cobra.Command {
+func NewDeployTopologyUpdaterCommand(env *deployer.Environment, commonOpts *deploy.Options, opts *DeployOptions) *cobra.Command {
 	deploy := &cobra.Command{
 		Use:   "topology-updater",
 		Short: "deploy the topology updater needed for topology-aware-scheduling",
@@ -217,7 +218,7 @@ func NewDeployTopologyUpdaterCommand(env *deployer.Environment, commonOpts *Comm
 				PlatformVersion: opts.clusterVersion,
 				WaitCompletion:  opts.waitCompletion,
 				RTEConfigData:   commonOpts.RTEConfigData,
-				DaemonSet:       daemonSetOptionsFromCommonOptions(commonOpts),
+				DaemonSet:       daemonSetOptionsFrom(commonOpts),
 				EnableCRIHooks:  commonOpts.UpdaterCRIHooksEnable,
 			})
 		},
@@ -226,7 +227,7 @@ func NewDeployTopologyUpdaterCommand(env *deployer.Environment, commonOpts *Comm
 	return deploy
 }
 
-func NewRemoveAPICommand(env *deployer.Environment, commonOpts *CommonOptions, opts *DeployOptions) *cobra.Command {
+func NewRemoveAPICommand(env *deployer.Environment, commonOpts *deploy.Options, opts *DeployOptions) *cobra.Command {
 	remove := &cobra.Command{
 		Use:   "api",
 		Short: "remove the APIs needed for topology-aware-scheduling",
@@ -259,7 +260,7 @@ func NewRemoveAPICommand(env *deployer.Environment, commonOpts *CommonOptions, o
 	return remove
 }
 
-func NewRemoveSchedulerPluginCommand(env *deployer.Environment, commonOpts *CommonOptions, opts *DeployOptions) *cobra.Command {
+func NewRemoveSchedulerPluginCommand(env *deployer.Environment, commonOpts *deploy.Options, opts *DeployOptions) *cobra.Command {
 	remove := &cobra.Command{
 		Use:   "scheduler-plugin",
 		Short: "remove the scheduler plugin needed for topology-aware-scheduling",
@@ -298,7 +299,7 @@ func NewRemoveSchedulerPluginCommand(env *deployer.Environment, commonOpts *Comm
 	return remove
 }
 
-func NewRemoveTopologyUpdaterCommand(env *deployer.Environment, commonOpts *CommonOptions, opts *DeployOptions) *cobra.Command {
+func NewRemoveTopologyUpdaterCommand(env *deployer.Environment, commonOpts *deploy.Options, opts *DeployOptions) *cobra.Command {
 	remove := &cobra.Command{
 		Use:   "topology-updater",
 		Short: "remove the topology updater needed for topology-aware-scheduling",
@@ -326,7 +327,7 @@ func NewRemoveTopologyUpdaterCommand(env *deployer.Environment, commonOpts *Comm
 				PlatformVersion: opts.clusterVersion,
 				WaitCompletion:  opts.waitCompletion,
 				RTEConfigData:   commonOpts.RTEConfigData,
-				DaemonSet:       daemonSetOptionsFromCommonOptions(commonOpts),
+				DaemonSet:       daemonSetOptionsFrom(commonOpts),
 				EnableCRIHooks:  commonOpts.UpdaterCRIHooksEnable,
 			})
 		},
@@ -335,7 +336,7 @@ func NewRemoveTopologyUpdaterCommand(env *deployer.Environment, commonOpts *Comm
 	return remove
 }
 
-func deployOnCluster(env *deployer.Environment, commonOpts *CommonOptions, opts *DeployOptions) error {
+func deployOnCluster(env *deployer.Environment, commonOpts *deploy.Options, opts *DeployOptions) error {
 	if err := env.EnsureClient(); err != nil {
 		return err
 	}
@@ -362,7 +363,7 @@ func deployOnCluster(env *deployer.Environment, commonOpts *CommonOptions, opts 
 		PlatformVersion: opts.clusterVersion,
 		WaitCompletion:  opts.waitCompletion,
 		RTEConfigData:   commonOpts.RTEConfigData,
-		DaemonSet:       daemonSetOptionsFromCommonOptions(commonOpts),
+		DaemonSet:       daemonSetOptionsFrom(commonOpts),
 		EnableCRIHooks:  commonOpts.UpdaterCRIHooksEnable,
 	}); err != nil {
 		return err

--- a/pkg/commands/detect.go
+++ b/pkg/commands/detect.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deploy"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform/detect"
 )
@@ -29,7 +30,7 @@ type detectOptions struct {
 	jsonOutput bool
 }
 
-func NewDetectCommand(env *deployer.Environment, commonOpts *CommonOptions) *cobra.Command {
+func NewDetectCommand(env *deployer.Environment, commonOpts *deploy.Options) *cobra.Command {
 	opts := &detectOptions{}
 	detect := &cobra.Command{
 		Use:   "detect",

--- a/pkg/commands/detect.go
+++ b/pkg/commands/detect.go
@@ -40,7 +40,7 @@ func NewDetectCommand(commonOpts *CommonOptions) *cobra.Command {
 			platKind, kindReason, _ := detect.FindPlatform(ctx, commonOpts.UserPlatform)
 			platVer, verReason, _ := detect.FindVersion(ctx, platKind.Discovered, commonOpts.UserPlatformVersion)
 
-			commonOpts.DebugLog.Info("detection", "platform", platKind, "reason", kindReason, "version", platVer, "source", verReason)
+			commonOpts.Log.Info("detection", "platform", platKind, "reason", kindReason, "version", platVer, "source", verReason)
 
 			cluster := detect.ClusterInfo{
 				Platform: platKind,

--- a/pkg/commands/images.go
+++ b/pkg/commands/images.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deploy"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/updaters"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/images"
@@ -31,7 +32,7 @@ type ImagesOptions struct {
 	rawOutput  bool
 }
 
-func NewImagesCommand(env *deployer.Environment, commonOpts *CommonOptions) *cobra.Command {
+func NewImagesCommand(env *deployer.Environment, commonOpts *deploy.Options) *cobra.Command {
 	opts := &ImagesOptions{}
 	images := &cobra.Command{
 		Use:   "images",

--- a/pkg/commands/images.go
+++ b/pkg/commands/images.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/updaters"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/images"
 )
@@ -30,7 +31,7 @@ type ImagesOptions struct {
 	rawOutput  bool
 }
 
-func NewImagesCommand(commonOpts *CommonOptions) *cobra.Command {
+func NewImagesCommand(env *deployer.Environment, commonOpts *CommonOptions) *cobra.Command {
 	opts := &ImagesOptions{}
 	images := &cobra.Command{
 		Use:   "images",

--- a/pkg/commands/render.go
+++ b/pkg/commands/render.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/updaters"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/manifests"
@@ -32,7 +33,7 @@ import (
 
 type RenderOptions struct{}
 
-func NewRenderCommand(commonOpts *CommonOptions) *cobra.Command {
+func NewRenderCommand(env *deployer.Environment, commonOpts *CommonOptions) *cobra.Command {
 	opts := &RenderOptions{}
 	render := &cobra.Command{
 		Use:   "render",
@@ -41,17 +42,17 @@ func NewRenderCommand(commonOpts *CommonOptions) *cobra.Command {
 			if commonOpts.UserPlatform == platform.Unknown {
 				return fmt.Errorf("must explicitely select a cluster platform")
 			}
-			return RenderManifests(commonOpts)
+			return RenderManifests(env, commonOpts)
 		},
 		Args: cobra.NoArgs,
 	}
-	render.AddCommand(NewRenderAPICommand(commonOpts, opts))
-	render.AddCommand(NewRenderSchedulerPluginCommand(commonOpts, opts))
-	render.AddCommand(NewRenderTopologyUpdaterCommand(commonOpts, opts))
+	render.AddCommand(NewRenderAPICommand(env, commonOpts, opts))
+	render.AddCommand(NewRenderSchedulerPluginCommand(env, commonOpts, opts))
+	render.AddCommand(NewRenderTopologyUpdaterCommand(env, commonOpts, opts))
 	return render
 }
 
-func NewRenderAPICommand(commonOpts *CommonOptions, opts *RenderOptions) *cobra.Command {
+func NewRenderAPICommand(env *deployer.Environment, commonOpts *CommonOptions, opts *RenderOptions) *cobra.Command {
 	render := &cobra.Command{
 		Use:   "api",
 		Short: "render the APIs needed for topology-aware-scheduling",
@@ -74,7 +75,7 @@ func NewRenderAPICommand(commonOpts *CommonOptions, opts *RenderOptions) *cobra.
 	return render
 }
 
-func NewRenderSchedulerPluginCommand(commonOpts *CommonOptions, opts *RenderOptions) *cobra.Command {
+func NewRenderSchedulerPluginCommand(env *deployer.Environment, commonOpts *CommonOptions, opts *RenderOptions) *cobra.Command {
 	render := &cobra.Command{
 		Use:   "scheduler-plugin",
 		Short: "render the scheduler plugin needed for topology-aware-scheduling",
@@ -97,7 +98,7 @@ func NewRenderSchedulerPluginCommand(commonOpts *CommonOptions, opts *RenderOpti
 				Replicas:         int32(commonOpts.Replicas),
 				PullIfNotPresent: commonOpts.PullIfNotPresent,
 			}
-			schedObjs, err := schedManifests.Render(commonOpts.Log, renderOpts)
+			schedObjs, err := schedManifests.Render(env.Log, renderOpts)
 			if err != nil {
 				return err
 			}
@@ -108,7 +109,7 @@ func NewRenderSchedulerPluginCommand(commonOpts *CommonOptions, opts *RenderOpti
 	return render
 }
 
-func NewRenderTopologyUpdaterCommand(commonOpts *CommonOptions, opts *RenderOptions) *cobra.Command {
+func NewRenderTopologyUpdaterCommand(env *deployer.Environment, commonOpts *CommonOptions, opts *RenderOptions) *cobra.Command {
 	render := &cobra.Command{
 		Use:   "topology-updater",
 		Short: "render the topology updater needed for topology-aware-scheduling",
@@ -148,7 +149,7 @@ func makeUpdaterObjects(commonOpts *CommonOptions) ([]client.Object, string, err
 	return append([]client.Object{ns}, objs...), namespace, nil
 }
 
-func RenderManifests(commonOpts *CommonOptions) error {
+func RenderManifests(env *deployer.Environment, commonOpts *CommonOptions) error {
 	var objs []client.Object
 
 	apiManifests, err := api.GetManifests(commonOpts.UserPlatform)
@@ -181,7 +182,7 @@ func RenderManifests(commonOpts *CommonOptions) error {
 		Verbose:           commonOpts.SchedVerbose,
 	}
 
-	schedObjs, err := schedManifests.Render(commonOpts.Log, schedRenderOpts)
+	schedObjs, err := schedManifests.Render(env.Log, schedRenderOpts)
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/render.go
+++ b/pkg/commands/render.go
@@ -139,7 +139,7 @@ func makeUpdaterObjects(commonOpts *deploy.Options) ([]client.Object, string, er
 		PlatformVersion: commonOpts.UserPlatformVersion,
 		Platform:        commonOpts.UserPlatform,
 		RTEConfigData:   commonOpts.RTEConfigData,
-		DaemonSet:       daemonSetOptionsFrom(commonOpts),
+		DaemonSet:       deploy.DaemonSetOptionsFrom(commonOpts),
 		EnableCRIHooks:  commonOpts.UpdaterCRIHooksEnable,
 	}
 	objs, err := updaters.GetObjects(opts, commonOpts.UpdaterType, namespace)

--- a/pkg/commands/render.go
+++ b/pkg/commands/render.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deploy"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/updaters"
@@ -33,7 +34,7 @@ import (
 
 type RenderOptions struct{}
 
-func NewRenderCommand(env *deployer.Environment, commonOpts *CommonOptions) *cobra.Command {
+func NewRenderCommand(env *deployer.Environment, commonOpts *deploy.Options) *cobra.Command {
 	opts := &RenderOptions{}
 	render := &cobra.Command{
 		Use:   "render",
@@ -52,7 +53,7 @@ func NewRenderCommand(env *deployer.Environment, commonOpts *CommonOptions) *cob
 	return render
 }
 
-func NewRenderAPICommand(env *deployer.Environment, commonOpts *CommonOptions, opts *RenderOptions) *cobra.Command {
+func NewRenderAPICommand(env *deployer.Environment, commonOpts *deploy.Options, opts *RenderOptions) *cobra.Command {
 	render := &cobra.Command{
 		Use:   "api",
 		Short: "render the APIs needed for topology-aware-scheduling",
@@ -75,7 +76,7 @@ func NewRenderAPICommand(env *deployer.Environment, commonOpts *CommonOptions, o
 	return render
 }
 
-func NewRenderSchedulerPluginCommand(env *deployer.Environment, commonOpts *CommonOptions, opts *RenderOptions) *cobra.Command {
+func NewRenderSchedulerPluginCommand(env *deployer.Environment, commonOpts *deploy.Options, opts *RenderOptions) *cobra.Command {
 	render := &cobra.Command{
 		Use:   "scheduler-plugin",
 		Short: "render the scheduler plugin needed for topology-aware-scheduling",
@@ -109,7 +110,7 @@ func NewRenderSchedulerPluginCommand(env *deployer.Environment, commonOpts *Comm
 	return render
 }
 
-func NewRenderTopologyUpdaterCommand(env *deployer.Environment, commonOpts *CommonOptions, opts *RenderOptions) *cobra.Command {
+func NewRenderTopologyUpdaterCommand(env *deployer.Environment, commonOpts *deploy.Options, opts *RenderOptions) *cobra.Command {
 	render := &cobra.Command{
 		Use:   "topology-updater",
 		Short: "render the topology updater needed for topology-aware-scheduling",
@@ -128,7 +129,7 @@ func NewRenderTopologyUpdaterCommand(env *deployer.Environment, commonOpts *Comm
 	return render
 }
 
-func makeUpdaterObjects(commonOpts *CommonOptions) ([]client.Object, string, error) {
+func makeUpdaterObjects(commonOpts *deploy.Options) ([]client.Object, string, error) {
 	ns, namespace, err := updaters.SetupNamespace(commonOpts.UpdaterType)
 	if err != nil {
 		return nil, namespace, err
@@ -138,7 +139,7 @@ func makeUpdaterObjects(commonOpts *CommonOptions) ([]client.Object, string, err
 		PlatformVersion: commonOpts.UserPlatformVersion,
 		Platform:        commonOpts.UserPlatform,
 		RTEConfigData:   commonOpts.RTEConfigData,
-		DaemonSet:       daemonSetOptionsFromCommonOptions(commonOpts),
+		DaemonSet:       daemonSetOptionsFrom(commonOpts),
 		EnableCRIHooks:  commonOpts.UpdaterCRIHooksEnable,
 	}
 	objs, err := updaters.GetObjects(opts, commonOpts.UpdaterType, namespace)
@@ -149,7 +150,7 @@ func makeUpdaterObjects(commonOpts *CommonOptions) ([]client.Object, string, err
 	return append([]client.Object{ns}, objs...), namespace, nil
 }
 
-func RenderManifests(env *deployer.Environment, commonOpts *CommonOptions) error {
+func RenderManifests(env *deployer.Environment, commonOpts *deploy.Options) error {
 	var objs []client.Object
 
 	apiManifests, err := api.GetManifests(commonOpts.UserPlatform)

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -24,12 +24,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-logr/logr"
 	"github.com/go-logr/stdr"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	"github.com/k8stopologyawareschedwg/deployer/pkg/clientutil"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/updaters"
@@ -47,7 +45,6 @@ const (
 type CommonOptions struct {
 	UserPlatform           platform.Platform
 	UserPlatformVersion    platform.Version
-	Log                    logr.Logger
 	Replicas               int
 	RTEConfigData          string
 	PullIfNotPresent       bool
@@ -63,9 +60,12 @@ type CommonOptions struct {
 	SchedCtrlPlaneAffinity bool
 	WaitInterval           time.Duration
 	WaitTimeout            time.Duration
-	rteConfigFile          string
-	plat                   string
-	platVer                string
+}
+
+type internalOptions struct {
+	rteConfigFile string
+	plat          string
+	platVer       string
 }
 
 func ShowHelp(cmd *cobra.Command, args []string) error {
@@ -73,18 +73,23 @@ func ShowHelp(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-type NewCommandFunc func(ko *CommonOptions) *cobra.Command
+type NewCommandFunc func(ev *deployer.Environment, ko *CommonOptions) *cobra.Command
 
 // NewRootCommand returns entrypoint command to interact with all other commands
 func NewRootCommand(extraCmds ...NewCommandFunc) *cobra.Command {
-	commonOpts := &CommonOptions{}
+	env := deployer.Environment{
+		Ctx: context.Background(),
+		Log: stdr.New(log.New(os.Stderr, "", log.LstdFlags)),
+	}
+	internalOpts := internalOptions{}
+	commonOpts := CommonOptions{}
 
 	root := &cobra.Command{
 		Use:   "deployer",
 		Short: "deployer helps setting up all the topology-aware-scheduling components on a kubernetes cluster",
 
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return PostSetupOptions(commonOpts)
+			return PostSetupOptions(&env, &commonOpts, &internalOpts)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return ShowHelp(cmd, args)
@@ -93,31 +98,32 @@ func NewRootCommand(extraCmds ...NewCommandFunc) *cobra.Command {
 		SilenceErrors: true,
 	}
 
-	InitFlags(root.PersistentFlags(), commonOpts)
+	InitFlags(root.PersistentFlags(), &commonOpts, &internalOpts)
 
 	root.AddCommand(
-		NewRenderCommand(commonOpts),
-		NewValidateCommand(commonOpts),
-		NewDeployCommand(commonOpts),
-		NewRemoveCommand(commonOpts),
-		NewSetupCommand(commonOpts),
-		NewDetectCommand(commonOpts),
-		NewImagesCommand(commonOpts),
+		NewRenderCommand(&env, &commonOpts),
+		NewValidateCommand(&env, &commonOpts),
+		NewDeployCommand(&env, &commonOpts),
+		NewRemoveCommand(&env, &commonOpts),
+		NewSetupCommand(&env, &commonOpts),
+		NewDetectCommand(&env, &commonOpts),
+		NewImagesCommand(&env, &commonOpts),
 	)
 	for _, extraCmd := range extraCmds {
-		root.AddCommand(extraCmd(commonOpts))
+		root.AddCommand(extraCmd(&env, &commonOpts))
 	}
 
 	return root
 }
 
-func InitFlags(flags *pflag.FlagSet, commonOpts *CommonOptions) {
-	flags.StringVarP(&commonOpts.plat, "platform", "P", "", "platform kind:version to deploy on (example kubernetes:v1.22)")
+func InitFlags(flags *pflag.FlagSet, commonOpts *CommonOptions, internalOpts *internalOptions) {
+	flags.StringVarP(&internalOpts.plat, "platform", "P", "", "platform kind:version to deploy on (example kubernetes:v1.22)")
+	flags.StringVar(&internalOpts.rteConfigFile, "rte-config-file", "", "inject rte configuration reading from this file.")
+
 	flags.IntVarP(&commonOpts.Replicas, "replicas", "R", 1, "set the replica value - where relevant.")
 	flags.DurationVarP(&commonOpts.WaitInterval, "wait-interval", "E", 2*time.Second, "wait interval.")
 	flags.DurationVarP(&commonOpts.WaitTimeout, "wait-timeout", "T", 2*time.Minute, "wait timeout.")
 	flags.BoolVar(&commonOpts.PullIfNotPresent, "pull-if-not-present", false, "force pull policies to IfNotPresent.")
-	flags.StringVar(&commonOpts.rteConfigFile, "rte-config-file", "", "inject rte configuration reading from this file.")
 	flags.StringVar(&commonOpts.UpdaterType, "updater-type", "RTE", "type of updater to deploy - RTE or NFD")
 	flags.BoolVar(&commonOpts.UpdaterPFPEnable, "updater-pfp-enable", true, "toggle PFP support on the updater side.")
 	flags.BoolVar(&commonOpts.UpdaterNotifEnable, "updater-notif-enable", true, "toggle event-based notification support on the updater side.")
@@ -130,35 +136,32 @@ func InitFlags(flags *pflag.FlagSet, commonOpts *CommonOptions) {
 	flags.BoolVar(&commonOpts.SchedCtrlPlaneAffinity, "sched-ctrlplane-affinity", true, "toggle the scheduler control plane affinity.")
 }
 
-func PostSetupOptions(commonOpts *CommonOptions) error {
-	// we abuse the logger to have a common interface and the timestamps
-	commonOpts.Log = stdr.New(log.New(os.Stderr, "", log.LstdFlags))
-
-	commonOpts.Log.V(3).Info("global polling interval=%v timeout=%v", commonOpts.WaitInterval, commonOpts.WaitTimeout)
+func PostSetupOptions(env *deployer.Environment, commonOpts *CommonOptions, internalOpts *internalOptions) error {
+	env.Log.V(3).Info("global polling interval=%v timeout=%v", commonOpts.WaitInterval, commonOpts.WaitTimeout)
 	wait.SetBaseValues(commonOpts.WaitInterval, commonOpts.WaitTimeout)
 
 	// if it is unknown, it's fine
-	if commonOpts.plat == "" {
+	if internalOpts.plat == "" {
 		commonOpts.UserPlatform = platform.Unknown
 		commonOpts.UserPlatformVersion = platform.MissingVersion
 	} else {
-		fields := strings.FieldsFunc(commonOpts.plat, func(c rune) bool {
+		fields := strings.FieldsFunc(internalOpts.plat, func(c rune) bool {
 			return c == ':'
 		})
 		if len(fields) != 2 {
-			return fmt.Errorf("unsupported platform spec: %q", commonOpts.plat)
+			return fmt.Errorf("unsupported platform spec: %q", internalOpts.plat)
 		}
 		commonOpts.UserPlatform, _ = platform.ParsePlatform(fields[0])
 		commonOpts.UserPlatformVersion, _ = platform.ParseVersion(fields[1])
 	}
 
-	if commonOpts.rteConfigFile != "" {
-		data, err := os.ReadFile(commonOpts.rteConfigFile)
+	if internalOpts.rteConfigFile != "" {
+		data, err := os.ReadFile(internalOpts.rteConfigFile)
 		if err != nil {
 			return err
 		}
 		commonOpts.RTEConfigData = string(data)
-		commonOpts.Log.Info("RTE config: read", "bytes", len(commonOpts.RTEConfigData))
+		env.Log.Info("RTE config: read", "bytes", len(commonOpts.RTEConfigData))
 	}
 	return validateUpdaterType(commonOpts.UpdaterType)
 }
@@ -168,18 +171,6 @@ func validateUpdaterType(updaterType string) error {
 		return fmt.Errorf("%q is invalid updater type", updaterType)
 	}
 	return nil
-}
-
-func environFromOpts(commonOpts *CommonOptions) (*deployer.Environment, error) {
-	cli, err := clientutil.New()
-	if err != nil {
-		return nil, err
-	}
-	return &deployer.Environment{
-		Ctx: context.Background(),
-		Cli: cli,
-		Log: commonOpts.Log,
-	}, nil
 }
 
 func daemonSetOptionsFromCommonOptions(commonOpts *CommonOptions) objectupdate.DaemonSetOptions {

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -33,7 +33,6 @@ import (
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/updaters"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/wait"
-	"github.com/k8stopologyawareschedwg/deployer/pkg/objectupdate"
 )
 
 // TODO: move elsewhere
@@ -152,14 +151,4 @@ func validateUpdaterType(updaterType string) error {
 		return fmt.Errorf("%q is invalid updater type", updaterType)
 	}
 	return nil
-}
-
-func daemonSetOptionsFrom(commonOpts *deploy.Options) objectupdate.DaemonSetOptions {
-	return objectupdate.DaemonSetOptions{
-		PullIfNotPresent:   commonOpts.PullIfNotPresent,
-		PFPEnable:          commonOpts.UpdaterPFPEnable,
-		NotificationEnable: commonOpts.UpdaterNotifEnable,
-		UpdateInterval:     commonOpts.UpdaterSyncPeriod,
-		Verbose:            commonOpts.UpdaterVerbose,
-	}
 }

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -45,11 +45,9 @@ const (
 )
 
 type CommonOptions struct {
-	Debug                  bool
 	UserPlatform           platform.Platform
 	UserPlatformVersion    platform.Version
 	Log                    logr.Logger
-	DebugLog               logr.Logger
 	Replicas               int
 	RTEConfigData          string
 	PullIfNotPresent       bool
@@ -114,7 +112,6 @@ func NewRootCommand(extraCmds ...NewCommandFunc) *cobra.Command {
 }
 
 func InitFlags(flags *pflag.FlagSet, commonOpts *CommonOptions) {
-	flags.BoolVarP(&commonOpts.Debug, "debug", "D", false, "enable debug log")
 	flags.StringVarP(&commonOpts.plat, "platform", "P", "", "platform kind:version to deploy on (example kubernetes:v1.22)")
 	flags.IntVarP(&commonOpts.Replicas, "replicas", "R", 1, "set the replica value - where relevant.")
 	flags.DurationVarP(&commonOpts.WaitInterval, "wait-interval", "E", 2*time.Second, "wait interval.")
@@ -136,11 +133,6 @@ func InitFlags(flags *pflag.FlagSet, commonOpts *CommonOptions) {
 func PostSetupOptions(commonOpts *CommonOptions) error {
 	// we abuse the logger to have a common interface and the timestamps
 	commonOpts.Log = stdr.New(log.New(os.Stderr, "", log.LstdFlags))
-	if commonOpts.Debug {
-		commonOpts.DebugLog = commonOpts.Log.WithName("DEBUG")
-	} else {
-		commonOpts.DebugLog = logr.Discard()
-	}
 
 	commonOpts.Log.V(3).Info("global polling interval=%v timeout=%v", commonOpts.WaitInterval, commonOpts.WaitTimeout)
 	wait.SetBaseValues(commonOpts.WaitInterval, commonOpts.WaitTimeout)
@@ -166,7 +158,7 @@ func PostSetupOptions(commonOpts *CommonOptions) error {
 			return err
 		}
 		commonOpts.RTEConfigData = string(data)
-		commonOpts.DebugLog.Info("RTE config: read", "bytes", len(commonOpts.RTEConfigData))
+		commonOpts.Log.Info("RTE config: read", "bytes", len(commonOpts.RTEConfigData))
 	}
 	return validateUpdaterType(commonOpts.UpdaterType)
 }

--- a/pkg/commands/setup.go
+++ b/pkg/commands/setup.go
@@ -17,10 +17,11 @@
 package commands
 
 import (
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer"
 	"github.com/spf13/cobra"
 )
 
-func NewSetupCommand(commonOpts *CommonOptions) *cobra.Command {
+func NewSetupCommand(env *deployer.Environment, commonOpts *CommonOptions) *cobra.Command {
 	depOpts := &DeployOptions{}
 	valOpts := &validateOptions{
 		outputMode: ValidateOutputLog,
@@ -29,10 +30,10 @@ func NewSetupCommand(commonOpts *CommonOptions) *cobra.Command {
 		Use:   "setup",
 		Short: "validate and setup a cluster to be used for topology-aware-scheduling",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := validateCluster(cmd, commonOpts, valOpts, args); err != nil {
+			if err := validateCluster(cmd, env, commonOpts, valOpts, args); err != nil {
 				return err
 			}
-			return deployOnCluster(commonOpts, depOpts)
+			return deployOnCluster(env, commonOpts, depOpts)
 		},
 		Args: cobra.NoArgs,
 	}

--- a/pkg/commands/setup.go
+++ b/pkg/commands/setup.go
@@ -23,7 +23,6 @@ import (
 )
 
 func NewSetupCommand(env *deployer.Environment, commonOpts *deploy.Options) *cobra.Command {
-	depOpts := &DeployOptions{}
 	valOpts := &validateOptions{
 		outputMode: ValidateOutputLog,
 	}
@@ -34,7 +33,7 @@ func NewSetupCommand(env *deployer.Environment, commonOpts *deploy.Options) *cob
 			if err := validateCluster(cmd, env, commonOpts, valOpts, args); err != nil {
 				return err
 			}
-			return deployOnCluster(env, commonOpts, depOpts)
+			return deployOnCluster(env, commonOpts)
 		},
 		Args: cobra.NoArgs,
 	}

--- a/pkg/commands/setup.go
+++ b/pkg/commands/setup.go
@@ -33,7 +33,7 @@ func NewSetupCommand(env *deployer.Environment, commonOpts *deploy.Options) *cob
 			if err := validateCluster(cmd, env, commonOpts, valOpts, args); err != nil {
 				return err
 			}
-			return deployOnCluster(env, commonOpts)
+			return deploy.OnCluster(env, commonOpts)
 		},
 		Args: cobra.NoArgs,
 	}

--- a/pkg/commands/setup.go
+++ b/pkg/commands/setup.go
@@ -17,11 +17,12 @@
 package commands
 
 import (
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deploy"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer"
 	"github.com/spf13/cobra"
 )
 
-func NewSetupCommand(env *deployer.Environment, commonOpts *CommonOptions) *cobra.Command {
+func NewSetupCommand(env *deployer.Environment, commonOpts *deploy.Options) *cobra.Command {
 	depOpts := &DeployOptions{}
 	valOpts := &validateOptions{
 		outputMode: ValidateOutputLog,

--- a/pkg/commands/validate.go
+++ b/pkg/commands/validate.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/k8stopologyawareschedwg/deployer/pkg/clientutil/nodes"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deploy"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/validator"
 )
@@ -43,7 +44,7 @@ type validateOptions struct {
 	jsonOutput bool
 }
 
-func NewValidateCommand(env *deployer.Environment, commonOpts *CommonOptions) *cobra.Command {
+func NewValidateCommand(env *deployer.Environment, commonOpts *deploy.Options) *cobra.Command {
 	opts := &validateOptions{}
 	validate := &cobra.Command{
 		Use:   "validate",
@@ -73,7 +74,7 @@ type validationOutput struct {
 	Errors  []validator.ValidationResult `json:"errors,omitempty"`
 }
 
-func validateCluster(cmd *cobra.Command, env *deployer.Environment, commonOpts *CommonOptions, opts *validateOptions, args []string) error {
+func validateCluster(cmd *cobra.Command, env *deployer.Environment, commonOpts *deploy.Options, opts *validateOptions, args []string) error {
 	// TODO
 	validatePostSetupOptions(opts)
 

--- a/pkg/commands/validate.go
+++ b/pkg/commands/validate.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/k8stopologyawareschedwg/deployer/pkg/clientutil/nodes"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/validator"
 )
 
@@ -42,13 +43,13 @@ type validateOptions struct {
 	jsonOutput bool
 }
 
-func NewValidateCommand(commonOpts *CommonOptions) *cobra.Command {
+func NewValidateCommand(env *deployer.Environment, commonOpts *CommonOptions) *cobra.Command {
 	opts := &validateOptions{}
 	validate := &cobra.Command{
 		Use:   "validate",
 		Short: "validate the cluster configuration to be correct for topology-aware-scheduling",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return validateCluster(cmd, commonOpts, opts, args)
+			return validateCluster(cmd, env, commonOpts, opts, args)
 		},
 		Args: cobra.NoArgs,
 	}
@@ -72,11 +73,11 @@ type validationOutput struct {
 	Errors  []validator.ValidationResult `json:"errors,omitempty"`
 }
 
-func validateCluster(cmd *cobra.Command, commonOpts *CommonOptions, opts *validateOptions, args []string) error {
+func validateCluster(cmd *cobra.Command, env *deployer.Environment, commonOpts *CommonOptions, opts *validateOptions, args []string) error {
 	// TODO
 	validatePostSetupOptions(opts)
 
-	env, err := environFromOpts(commonOpts)
+	err := env.EnsureClient()
 	if err != nil {
 		return err
 	}

--- a/pkg/deploy/cluster.go
+++ b/pkg/deploy/cluster.go
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ */
+
+package deploy
+
+import (
+	"fmt"
+
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/api"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform/detect"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/sched"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/updaters"
+	"github.com/k8stopologyawareschedwg/deployer/pkg/objectupdate"
+)
+
+func OnCluster(env *deployer.Environment, commonOpts *Options) error {
+	if err := env.EnsureClient(); err != nil {
+		return err
+	}
+
+	platDetect, reason, _ := detect.FindPlatform(env.Ctx, commonOpts.UserPlatform)
+	commonOpts.ClusterPlatform = platDetect.Discovered
+	if commonOpts.ClusterPlatform == platform.Unknown {
+		return fmt.Errorf("cannot autodetect the platform, and no platform given")
+	}
+	versionDetect, source, _ := detect.FindVersion(env.Ctx, platDetect.Discovered, commonOpts.UserPlatformVersion)
+	commonOpts.ClusterVersion = versionDetect.Discovered
+	if commonOpts.ClusterVersion == platform.MissingVersion {
+		return fmt.Errorf("cannot autodetect the platform version, and no version given")
+	}
+
+	env.Log.Info("detection", "platform", commonOpts.ClusterPlatform, "reason", reason, "version", commonOpts.ClusterVersion, "source", source)
+	if err := api.Deploy(env, api.Options{
+		Platform: commonOpts.ClusterPlatform,
+	}); err != nil {
+		return err
+	}
+	if err := updaters.Deploy(env, commonOpts.UpdaterType, updaters.Options{
+		Platform:        commonOpts.ClusterPlatform,
+		PlatformVersion: commonOpts.ClusterVersion,
+		WaitCompletion:  commonOpts.WaitCompletion,
+		RTEConfigData:   commonOpts.RTEConfigData,
+		DaemonSet:       DaemonSetOptionsFrom(commonOpts),
+		EnableCRIHooks:  commonOpts.UpdaterCRIHooksEnable,
+	}); err != nil {
+		return err
+	}
+	if err := sched.Deploy(env, sched.Options{
+		Platform:          commonOpts.ClusterPlatform,
+		WaitCompletion:    commonOpts.WaitCompletion,
+		Replicas:          int32(commonOpts.Replicas),
+		RTEConfigData:     commonOpts.RTEConfigData,
+		PullIfNotPresent:  commonOpts.PullIfNotPresent,
+		CacheResyncPeriod: commonOpts.SchedResyncPeriod,
+		CtrlPlaneAffinity: commonOpts.SchedCtrlPlaneAffinity,
+		Verbose:           commonOpts.SchedVerbose,
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func DaemonSetOptionsFrom(commonOpts *Options) objectupdate.DaemonSetOptions {
+	return objectupdate.DaemonSetOptions{
+		PullIfNotPresent:   commonOpts.PullIfNotPresent,
+		PFPEnable:          commonOpts.UpdaterPFPEnable,
+		NotificationEnable: commonOpts.UpdaterNotifEnable,
+		UpdateInterval:     commonOpts.UpdaterSyncPeriod,
+		Verbose:            commonOpts.UpdaterVerbose,
+	}
+}

--- a/pkg/deploy/types.go
+++ b/pkg/deploy/types.go
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ */
+
+package deploy
+
+import (
+	"time"
+
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
+)
+
+type Options struct {
+	UserPlatform           platform.Platform
+	UserPlatformVersion    platform.Version
+	Replicas               int
+	RTEConfigData          string
+	PullIfNotPresent       bool
+	UpdaterType            string
+	UpdaterPFPEnable       bool
+	UpdaterNotifEnable     bool
+	UpdaterCRIHooksEnable  bool
+	UpdaterSyncPeriod      time.Duration
+	UpdaterVerbose         int
+	SchedProfileName       string
+	SchedResyncPeriod      time.Duration
+	SchedVerbose           int
+	SchedCtrlPlaneAffinity bool
+	WaitInterval           time.Duration
+	WaitTimeout            time.Duration
+}

--- a/pkg/deploy/types.go
+++ b/pkg/deploy/types.go
@@ -40,4 +40,7 @@ type Options struct {
 	SchedCtrlPlaneAffinity bool
 	WaitInterval           time.Duration
 	WaitTimeout            time.Duration
+	ClusterPlatform        platform.Platform
+	ClusterVersion         platform.Version
+	WaitCompletion         bool
 }

--- a/pkg/deployer/deployer.go
+++ b/pkg/deployer/deployer.go
@@ -22,12 +22,23 @@ import (
 	"github.com/go-logr/logr"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/k8stopologyawareschedwg/deployer/pkg/clientutil"
 )
 
 type Environment struct {
 	Ctx context.Context
 	Cli client.Client
 	Log logr.Logger
+}
+
+func (env *Environment) EnsureClient() error {
+	cli, err := clientutil.New()
+	if err != nil {
+		return err
+	}
+	env.Cli = cli
+	return nil
 }
 
 func (env *Environment) WithName(name string) *Environment {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -151,7 +151,6 @@ func ensureNodeResourceTopology(tc *topologyclientset.Clientset, namespace, name
 func deploy(updaterType string, pfpEnable bool) error {
 	cmdline := []string{
 		filepath.Join(binariesPath, "deployer"),
-		"--debug",
 		"deploy",
 		"--rte-config-file=" + filepath.Join(deployerBaseDir, "hack", "rte.yaml"),
 		"--updater-pfp-enable=" + strconv.FormatBool(pfpEnable),
@@ -173,7 +172,6 @@ func deploy(updaterType string, pfpEnable bool) error {
 func remove(updaterType string) error {
 	cmdline := []string{
 		filepath.Join(binariesPath, "deployer"),
-		"--debug",
 		"remove",
 		"--wait",
 	}

--- a/test/e2e/positive.go
+++ b/test/e2e/positive.go
@@ -438,13 +438,13 @@ var _ = ginkgo.Describe("[PositiveFlow] Deployer partial execution", func() {
 			binPath := filepath.Join(binariesPath, "deployer")
 
 			err := runCmdline(
-				[]string{binPath, "--debug", "deploy", "api", "--wait"},
+				[]string{binPath, "deploy", "api", "--wait"},
 				"failed to deploy partial components before test started",
 			)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			err = runCmdline(
-				[]string{binPath, "--debug", "deploy", "scheduler-plugin", "--sched-ctrlplane-affinity=false", "--wait"},
+				[]string{binPath, "deploy", "scheduler-plugin", "--sched-ctrlplane-affinity=false", "--wait"},
 				"failed to deploy partial components before test started",
 			)
 			if err != nil {
@@ -454,13 +454,13 @@ var _ = ginkgo.Describe("[PositiveFlow] Deployer partial execution", func() {
 
 			defer func() {
 				err := runCmdline(
-					[]string{binPath, "--debug", "remove", "scheduler-plugin", "--wait"},
+					[]string{binPath, "remove", "scheduler-plugin", "--wait"},
 					"failed to remove partial components after test finished",
 				)
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 				err = runCmdline(
-					[]string{binPath, "--debug", "remove", "api", "--wait"},
+					[]string{binPath, "remove", "api", "--wait"},
 					"failed to remove partial components after test finished",
 				)
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
@@ -473,13 +473,13 @@ var _ = ginkgo.Describe("[PositiveFlow] Deployer partial execution", func() {
 			binPath := filepath.Join(binariesPath, "deployer")
 
 			err := runCmdline(
-				[]string{binPath, "--debug", "deploy", "api", "--wait"},
+				[]string{binPath, "deploy", "api", "--wait"},
 				"failed to deploy partial components before test started",
 			)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			err = runCmdline(
-				[]string{binPath, "--debug", "--sched-verbose=9", "deploy", "scheduler-plugin", "--sched-ctrlplane-affinity=false", "--wait"},
+				[]string{binPath, "--sched-verbose=9", "deploy", "scheduler-plugin", "--sched-ctrlplane-affinity=false", "--wait"},
 				"failed to deploy partial components before test started",
 			)
 			if err != nil {
@@ -489,13 +489,13 @@ var _ = ginkgo.Describe("[PositiveFlow] Deployer partial execution", func() {
 
 			defer func() {
 				err := runCmdline(
-					[]string{binPath, "--debug", "remove", "scheduler-plugin", "--wait"},
+					[]string{binPath, "remove", "scheduler-plugin", "--wait"},
 					"failed to remove partial components after test finished",
 				)
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 				err = runCmdline(
-					[]string{binPath, "--debug", "remove", "api", "--wait"},
+					[]string{binPath, "remove", "api", "--wait"},
 					"failed to remove partial components after test finished",
 				)
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())


### PR DESCRIPTION
code in `pkg/commands` should do orchestration and compose functionality exposed by other packages; instead, we gathered some helper/logic in there, which should be moved elsewhere. We start with the `deployOnCluster` and `deploy` functionality in general, moving this into a newly created small `deploy` package (we are running out good names).

This enables us to do quite some long-needed cleanup along the way.

Fixes: #138 