### PR TITLE
golangci-lint add developer config and related fixes

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,36 @@
+run:
+  timeout: 5m
+  tests: false
+  skip-dirs:
+    - vendor
+    - test
+  modules-download-mode: vendor
+linters:
+  disable-all: true
+  enable:
+    - errcheck
+    - bodyclose
+    - exportloopref
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - nolintlint
+    - nosprintfhostport
+    - staticcheck
+    - tenv
+    - typecheck
+    - unconvert
+    - unused
+    - wastedassign
+    - whitespace
+linters-settings:
+  misspell:
+    locale: US
+    ignore-words:
+      - NRO
+      - nro
+      - numaresource
+      - numa
+      - NUMA
+

--- a/cmd/deployer/main.go
+++ b/cmd/deployer/main.go
@@ -37,7 +37,7 @@ func NewVersionCommand(env *deployer.Environment, commonOpts *deploy.Options) *c
 	opts := versionOptions{}
 	version := &cobra.Command{
 		Use:   "version",
-		Short: "emit the version and exits succesfully",
+		Short: "emit the version and exits successfully",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if opts.hashOnly {
 				fmt.Printf("%s\n", deployerversion.GitCommit)

--- a/pkg/commands/render.go
+++ b/pkg/commands/render.go
@@ -41,7 +41,7 @@ func NewRenderCommand(env *deployer.Environment, commonOpts *deploy.Options) *co
 		Short: "render all the manifests",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if commonOpts.UserPlatform == platform.Unknown {
-				return fmt.Errorf("must explicitely select a cluster platform")
+				return fmt.Errorf("must explicitly select a cluster platform")
 			}
 			return RenderManifests(env, commonOpts)
 		},
@@ -59,7 +59,7 @@ func NewRenderAPICommand(env *deployer.Environment, commonOpts *deploy.Options, 
 		Short: "render the APIs needed for topology-aware-scheduling",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if commonOpts.UserPlatform == platform.Unknown {
-				return fmt.Errorf("must explicitely select a cluster platform")
+				return fmt.Errorf("must explicitly select a cluster platform")
 			}
 			apiManifests, err := api.GetManifests(commonOpts.UserPlatform)
 			if err != nil {
@@ -82,7 +82,7 @@ func NewRenderSchedulerPluginCommand(env *deployer.Environment, commonOpts *depl
 		Short: "render the scheduler plugin needed for topology-aware-scheduling",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if commonOpts.UserPlatform == platform.Unknown {
-				return fmt.Errorf("must explicitely select a cluster platform")
+				return fmt.Errorf("must explicitly select a cluster platform")
 			}
 
 			_, namespace, err := updaters.SetupNamespace(commonOpts.UpdaterType)
@@ -116,7 +116,7 @@ func NewRenderTopologyUpdaterCommand(env *deployer.Environment, commonOpts *depl
 		Short: "render the topology updater needed for topology-aware-scheduling",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if commonOpts.UserPlatform == platform.Unknown {
-				return fmt.Errorf("must explicitely select a cluster platform")
+				return fmt.Errorf("must explicitly select a cluster platform")
 			}
 			objs, _, err := makeUpdaterObjects(commonOpts)
 			if err != nil {

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -45,7 +45,6 @@ const (
 type internalOptions struct {
 	rteConfigFile string
 	plat          string
-	platVer       string
 }
 
 func ShowHelp(cmd *cobra.Command, args []string) error {

--- a/pkg/deployer/updaters/objects.go
+++ b/pkg/deployer/updaters/objects.go
@@ -30,7 +30,6 @@ import (
 )
 
 func GetObjects(opts Options, updaterType, namespace string) ([]client.Object, error) {
-
 	if updaterType == RTE {
 		mf, err := rtemanifests.GetManifests(opts.Platform, opts.PlatformVersion, namespace, opts.EnableCRIHooks)
 		if err != nil {

--- a/pkg/flagcodec/flagcodec.go
+++ b/pkg/flagcodec/flagcodec.go
@@ -16,7 +16,7 @@
 
 // flagcodec allows to manipulate foreign command lines following the
 // standard golang conventions. It offeres two-way processing aka
-// parsing/marshalling of flags. It is different from the other, well
+// parsing/marshaling of flags. It is different from the other, well
 // established packages (pflag...) because it aims to manipulate command
 // lines in general, not this program command line.
 
@@ -49,7 +49,7 @@ func ParseArgvKeyValue(args []string) *Flags {
 
 // ParseArgvKeyValue parses a clean (trimmed) argv whose components are
 // either toggles or key=value pairs. IOW, this is a restricted and easier
-// to parse flavour of argv on which option and value are guaranteed to
+// to parse flavor of argv on which option and value are guaranteed to
 // be in the same item.
 // IOW, we expect
 // "--opt=foo"

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -386,8 +386,8 @@ func makeIgnitionConfig(ver platform.Version, withCRIHooks bool) ([]byte, error)
 		Systemd: igntypes.Systemd{
 			Units: []igntypes.Unit{
 				{
-					Contents: pointer.StringPtr(string(systemdServiceContent)),
-					Enabled:  pointer.BoolPtr(true),
+					Contents: pointer.String(string(systemdServiceContent)),
+					Enabled:  pointer.Bool(true),
 					Name:     selinuxassets.RTEPolicyInstallServiceName,
 				},
 			},
@@ -405,9 +405,9 @@ func addFileToIgnitionConfig(files []igntypes.File, fileContent []byte, mode int
 		},
 		FileEmbedded1: igntypes.FileEmbedded1{
 			Contents: igntypes.Resource{
-				Source: pointer.StringPtr(fmt.Sprintf("%s,%s", defaultIgnitionContentSource, base64FileContent)),
+				Source: pointer.String(fmt.Sprintf("%s,%s", defaultIgnitionContentSource, base64FileContent)),
 			},
-			Mode: pointer.IntPtr(mode),
+			Mode: pointer.Int(mode),
 		},
 	})
 

--- a/pkg/objectupdate/nfd/nfd.go
+++ b/pkg/objectupdate/nfd/nfd.go
@@ -46,7 +46,7 @@ func UpdaterDaemonSet(ds *appsv1.DaemonSet, opts objectupdate.DaemonSetOptions) 
 
 		flags.SetOption("--pods-fingerprint", strconv.FormatBool(opts.PFPEnable))
 
-		// we need to explicitely disable the kubelet state dir monitoring, which is opt-out
+		// we need to explicitly disable the kubelet state dir monitoring, which is opt-out
 		flags.SetOption("--kubelet-state-dir", "")
 
 		c.Args = flags.Argv()

--- a/pkg/objectupdate/rte/rte.go
+++ b/pkg/objectupdate/rte/rte.go
@@ -72,7 +72,6 @@ func ContainerConfig(podSpec *corev1.PodSpec, cnt *corev1.Container, configMapNa
 func DaemonSet(ds *appsv1.DaemonSet, plat platform.Platform, configMapName string, opts objectupdate.DaemonSetOptions) {
 	podSpec := &ds.Spec.Template.Spec
 	if cntSpec := objectupdate.FindContainerByName(ds.Spec.Template.Spec.Containers, manifests.ContainerNameRTE); cntSpec != nil {
-
 		cntSpec.Image = images.ResourceTopologyExporterImage
 
 		cntSpec.ImagePullPolicy = corev1.PullAlways

--- a/pkg/objectupdate/sched/sched.go
+++ b/pkg/objectupdate/sched/sched.go
@@ -76,7 +76,7 @@ func SchedulerConfig(cm *corev1.ConfigMap, schedulerName string, cacheResyncPeri
 		return err
 	}
 
-	cm.Data[SchedulerConfigFileName] = string(newData)
+	cm.Data[SchedulerConfigFileName] = newData
 	return nil
 }
 

--- a/pkg/stringify/noderesourcetopology.go
+++ b/pkg/stringify/noderesourcetopology.go
@@ -94,7 +94,7 @@ func NodeResourceTopologyList(nrts []nrtv1alpha2.NodeResourceTopology, tag strin
 	}
 	fmt.Fprintf(&b, "\n")
 	for idx := range nrts {
-		fmt.Fprintf(&b, NodeResourceTopology(nrts[idx]))
+		fmt.Fprint(&b, NodeResourceTopology(nrts[idx]))
 	}
 	fmt.Fprintf(&b, "NRT END dump\n")
 	return b.String()


### PR DESCRIPTION
Add new makefile target to run golangci-lint and to be used by developers.
Later (soonish) we will integrate golangci-lint in CI using the recommended GH action.

This PR also includes a batch of related fixes for the issues raised by the golangci-lint run.
