### PR TITLE
wait: add helpers for CRDs

### DIFF
--- a/pkg/deployer/sched/sched.go
+++ b/pkg/deployer/sched/sched.go
@@ -69,11 +69,14 @@ func Deploy(env *deployer.Environment, opts Options) error {
 		if err := env.CreateObject(wo.Obj); err != nil {
 			return err
 		}
-		if opts.WaitCompletion && wo.Wait != nil {
-			err = wo.Wait(env.Ctx)
-			if err != nil {
-				return err
-			}
+
+		if !opts.WaitCompletion || wo.Wait == nil {
+			continue
+		}
+
+		err = wo.Wait(env.Ctx)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/pkg/deployer/updaters/updaters.go
+++ b/pkg/deployer/updaters/updaters.go
@@ -66,11 +66,14 @@ func Deploy(env *deployer.Environment, updaterType string, opts Options) error {
 		if err := env.CreateObject(wo.Obj); err != nil {
 			return err
 		}
-		if opts.WaitCompletion && wo.Wait != nil {
-			err = wo.Wait(env.Ctx)
-			if err != nil {
-				return err
-			}
+
+		if !opts.WaitCompletion || wo.Wait == nil {
+			continue
+		}
+
+		err = wo.Wait(env.Ctx)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/pkg/deployer/wait/crd.go
+++ b/pkg/deployer/wait/crd.go
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wait
+
+import (
+	"context"
+
+	apiextensionv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	k8swait "k8s.io/apimachinery/pkg/util/wait"
+)
+
+func (wt Waiter) ForCRDCreated(ctx context.Context, name string) (*apiextensionv1.CustomResourceDefinition, error) {
+	key := ObjectKey{Name: name}
+	crd := &apiextensionv1.CustomResourceDefinition{}
+	err := k8swait.PollImmediate(wt.PollInterval, wt.PollTimeout, func() (bool, error) {
+		err := wt.Cli.Get(ctx, key.AsKey(), crd)
+		if err != nil {
+			wt.Log.Info("failed to get the CRD", "key", key.String(), "error", err)
+			return false, err
+		}
+
+		wt.Log.Info("CRD available", "key", key.String())
+		return true, nil
+	})
+	return crd, err
+}
+
+func (wt Waiter) ForCRDDeleted(ctx context.Context, name string) error {
+	return k8swait.PollImmediate(wt.PollInterval, wt.PollTimeout, func() (bool, error) {
+		obj := apiextensionv1.CustomResourceDefinition{}
+		key := ObjectKey{Name: name}
+		err := wt.Cli.Get(ctx, key.AsKey(), &obj)
+		return deletionStatusFromError(wt.Log, "CRD", key, err)
+	})
+}

--- a/pkg/objectwait/api/api.go
+++ b/pkg/objectwait/api/api.go
@@ -17,22 +17,36 @@
 package api
 
 import (
+	"context"
+
 	"github.com/go-logr/logr"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/wait"
 	apimf "github.com/k8stopologyawareschedwg/deployer/pkg/manifests/api"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/objectwait"
 )
 
 func Creatable(mf apimf.Manifests, cli client.Client, log logr.Logger) []objectwait.WaitableObject {
 	return []objectwait.WaitableObject{
-		{Obj: mf.Crd},
+		{
+			Obj: mf.Crd,
+			Wait: func(ctx context.Context) error {
+				_, err := wait.With(cli, log).ForCRDCreated(ctx, mf.Crd.Name)
+				return err
+			},
+		},
 	}
 }
 
 func Deletable(mf apimf.Manifests, cli client.Client, log logr.Logger) []objectwait.WaitableObject {
 	return []objectwait.WaitableObject{
-		{Obj: mf.Crd},
+		{
+			Obj: mf.Crd,
+			Wait: func(ctx context.Context) error {
+				return wait.With(cli, log).ForCRDDeleted(ctx, mf.Crd.Name)
+			},
+		},
 	}
 }


### PR DESCRIPTION
Add wait functions for CRD created/deleted.
Creating and deleting CRDs is expected to be fast, but not immediate. In CI envs, we can have flakes because CRDs are not deleted fast enough and the attempt to re-create thus fails, failing the test.

In all practical environments the operation should be so fast that the extra gets/wait time should
be negligible - and in general we do this steps
very rarely, in the order of 1-2 times per *cluster* lifespan.

Considering the cost is expected to be negligible and that the code is now more correct, we add and
use functions, which should also reduce e2e flakes.