### PR TITLE
sched: manifests: v1beta2 -> v1beta3

### DIFF
--- a/pkg/manifests/schedparams_test.go
+++ b/pkg/manifests/schedparams_test.go
@@ -40,7 +40,7 @@ func TestDecodeSchedulerConfigFromData(t *testing.T) {
 		},
 		{
 			name: "bad scheduler name",
-			data: []byte(`apiVersion: kubescheduler.config.k8s.io/v1beta2
+			data: []byte(`apiVersion: kubescheduler.config.k8s.io/v1beta3
 kind: KubeSchedulerConfiguration
 leaderElection:
   leaderElect: false
@@ -65,7 +65,7 @@ profiles:
 		},
 		{
 			name: "bad scheduler params name",
-			data: []byte(`apiVersion: kubescheduler.config.k8s.io/v1beta2
+			data: []byte(`apiVersion: kubescheduler.config.k8s.io/v1beta3
 kind: KubeSchedulerConfiguration
 leaderElection:
   leaderElect: false
@@ -90,7 +90,7 @@ profiles:
 		},
 		{
 			name: "empty params",
-			data: []byte(`apiVersion: kubescheduler.config.k8s.io/v1beta2
+			data: []byte(`apiVersion: kubescheduler.config.k8s.io/v1beta3
 kind: KubeSchedulerConfiguration
 leaderElection:
   leaderElect: false
@@ -119,7 +119,7 @@ profiles:
 		},
 		{
 			name: "nonzero resync period",
-			data: []byte(`apiVersion: kubescheduler.config.k8s.io/v1beta2
+			data: []byte(`apiVersion: kubescheduler.config.k8s.io/v1beta3
 kind: KubeSchedulerConfiguration
 leaderElection:
   leaderElect: false

--- a/pkg/manifests/yaml/sched/configmap.yaml
+++ b/pkg/manifests/yaml/sched/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: tas-scheduler
 data:
   scheduler-config.yaml: |
-    apiVersion: kubescheduler.config.k8s.io/v1beta2
+    apiVersion: kubescheduler.config.k8s.io/v1beta3
     kind: KubeSchedulerConfiguration
     leaderElection:
       leaderElect: false

--- a/pkg/objectupdate/sched/render_test.go
+++ b/pkg/objectupdate/sched/render_test.go
@@ -74,7 +74,7 @@ func TestRenderConfig(t *testing.T) {
 				},
 			},
 			initial: configTemplateAllValues,
-			expected: `apiVersion: kubescheduler.config.k8s.io/v1beta2
+			expected: `apiVersion: kubescheduler.config.k8s.io/v1beta3
 kind: KubeSchedulerConfiguration
 leaderElection:
   leaderElect: false
@@ -105,7 +105,7 @@ profiles:
 				},
 			},
 			initial: configTemplateEmpty,
-			expected: `apiVersion: kubescheduler.config.k8s.io/v1beta2
+			expected: `apiVersion: kubescheduler.config.k8s.io/v1beta3
 kind: KubeSchedulerConfiguration
 leaderElection:
   leaderElect: false
@@ -145,7 +145,7 @@ profiles:
 				ProfileName: "renamed-sched",
 			},
 			initial: configTemplateAllValuesMulti,
-			expected: `apiVersion: kubescheduler.config.k8s.io/v1beta2
+			expected: `apiVersion: kubescheduler.config.k8s.io/v1beta3
 kind: KubeSchedulerConfiguration
 leaderElection:
   leaderElect: false
@@ -183,7 +183,7 @@ profiles:
 				},
 			},
 			initial: configTemplateAllValuesMulti,
-			expected: `apiVersion: kubescheduler.config.k8s.io/v1beta2
+			expected: `apiVersion: kubescheduler.config.k8s.io/v1beta3
 kind: KubeSchedulerConfiguration
 leaderElection:
   leaderElect: false
@@ -239,7 +239,7 @@ profiles:
 	}
 }
 
-var configTemplateEmpty string = `apiVersion: kubescheduler.config.k8s.io/v1beta2
+var configTemplateEmpty string = `apiVersion: kubescheduler.config.k8s.io/v1beta3
 kind: KubeSchedulerConfiguration
 leaderElection:
   leaderElect: false
@@ -260,7 +260,7 @@ profiles:
   schedulerName: test-sched-name
 `
 
-var configTemplateAllValues string = `apiVersion: kubescheduler.config.k8s.io/v1beta2
+var configTemplateAllValues string = `apiVersion: kubescheduler.config.k8s.io/v1beta3
 kind: KubeSchedulerConfiguration
 leaderElection:
   leaderElect: false
@@ -282,7 +282,7 @@ profiles:
   schedulerName: test-sched-name
 `
 
-var configTemplateAllValuesMulti string = `apiVersion: kubescheduler.config.k8s.io/v1beta2
+var configTemplateAllValuesMulti string = `apiVersion: kubescheduler.config.k8s.io/v1beta3
 kind: KubeSchedulerConfiguration
 leaderElection:
   leaderElect: false
@@ -311,7 +311,7 @@ profiles:
   schedulerName: test-sched-name
 `
 
-var configTemplateAllValuesMultiRenamed string = `apiVersion: kubescheduler.config.k8s.io/v1beta2
+var configTemplateAllValuesMultiRenamed string = `apiVersion: kubescheduler.config.k8s.io/v1beta3
 kind: KubeSchedulerConfiguration
 leaderElection:
   leaderElect: false


### PR DESCRIPTION
v1beta2 config is deprectated and on its way to removal. For our goals, though, v1beta3 should be fully compatible and little more than a trivial rename (if at all). Let's start with the trivial rename.