### PR TITLE
manifests: objectupdate: cache fine-tuning support

### DIFF
--- a/pkg/manifests/schedparams_test.go
+++ b/pkg/manifests/schedparams_test.go
@@ -149,6 +149,111 @@ profiles:
 			},
 			expectedFound: true,
 		},
+		{
+			name: "nonzero resync period and all cache params",
+			data: []byte(`apiVersion: kubescheduler.config.k8s.io/v1beta3
+kind: KubeSchedulerConfiguration
+leaderElection:
+  leaderElect: false
+profiles:
+- pluginConfig:
+  - args:
+      cache:
+        foreignPodsDetect: None
+        resyncMethod: Autodetect
+      cacheResyncPeriodSeconds: 5
+    name: NodeResourceTopologyMatch
+  plugins:
+    filter:
+      enabled:
+      - name: NodeResourceTopologyMatch
+    reserve:
+      enabled:
+      - name: NodeResourceTopologyMatch
+    score:
+      enabled:
+      - name: NodeResourceTopologyMatch
+  schedulerName: topology-aware-scheduler
+`),
+			schedulerName: "topology-aware-scheduler",
+			expectedParams: ConfigParams{
+				ProfileName: "topology-aware-scheduler",
+				Cache: &ConfigCacheParams{
+					ResyncPeriodSeconds:   newInt64(5),
+					ResyncMethod:          newString("Autodetect"),
+					ForeignPodsDetectMode: newString("None"),
+				},
+			},
+			expectedFound: true,
+		},
+		{
+			name: "nonzero resync period and some cache params",
+			data: []byte(`apiVersion: kubescheduler.config.k8s.io/v1beta3
+kind: KubeSchedulerConfiguration
+leaderElection:
+  leaderElect: false
+profiles:
+- pluginConfig:
+  - args:
+      cache:
+        resyncMethod: OnlyExclusiveResources
+      cacheResyncPeriodSeconds: 5
+    name: NodeResourceTopologyMatch
+  plugins:
+    filter:
+      enabled:
+      - name: NodeResourceTopologyMatch
+    reserve:
+      enabled:
+      - name: NodeResourceTopologyMatch
+    score:
+      enabled:
+      - name: NodeResourceTopologyMatch
+  schedulerName: topology-aware-scheduler
+`),
+			schedulerName: "topology-aware-scheduler",
+			expectedParams: ConfigParams{
+				ProfileName: "topology-aware-scheduler",
+				Cache: &ConfigCacheParams{
+					ResyncPeriodSeconds: newInt64(5),
+					ResyncMethod:        newString("OnlyExclusiveResources"),
+				},
+			},
+			expectedFound: true,
+		},
+		{
+			name: "zero resync period and some cache params",
+			data: []byte(`apiVersion: kubescheduler.config.k8s.io/v1beta3
+kind: KubeSchedulerConfiguration
+leaderElection:
+  leaderElect: false
+profiles:
+- pluginConfig:
+  - args:
+      cache:
+        foreignPodsDetect: OnlyExclusiveResources
+    name: NodeResourceTopologyMatch
+  plugins:
+    filter:
+      enabled:
+      - name: NodeResourceTopologyMatch
+    reserve:
+      enabled:
+      - name: NodeResourceTopologyMatch
+    score:
+      enabled:
+      - name: NodeResourceTopologyMatch
+  schedulerName: topology-aware-scheduler
+`),
+			schedulerName: "topology-aware-scheduler",
+			expectedParams: ConfigParams{
+				ProfileName: "topology-aware-scheduler",
+				Cache: &ConfigCacheParams{
+					ForeignPodsDetectMode: newString("OnlyExclusiveResources"),
+				},
+			},
+			expectedFound: true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -185,5 +290,9 @@ func toJSON(v any) string {
 }
 
 func newInt64(value int64) *int64 {
+	return &value
+}
+
+func newString(value string) *string {
 	return &value
 }

--- a/pkg/objectupdate/sched/render.go
+++ b/pkg/objectupdate/sched/render.go
@@ -167,7 +167,61 @@ func updateArgs(args map[string]interface{}, params *manifests.ConfigParams) (bo
 			updated++
 		}
 	}
+
+	cacheArgs, ok, err := unstructured.NestedMap(args, "cache")
+	if !ok {
+		cacheArgs = make(map[string]interface{})
+	}
+	if err != nil {
+		return updated > 0, err
+	}
+
+	cacheArgsUpdated, err := updateCacheArgs(cacheArgs, params)
+	if err != nil {
+		return updated > 0, err
+	}
+	updated += cacheArgsUpdated
+
+	if cacheArgsUpdated > 0 {
+		if err := unstructured.SetNestedMap(args, cacheArgs, "cache"); err != nil {
+			return updated > 0, err
+		}
+	}
 	return updated > 0, ensureBackwardCompatibility(args)
+}
+
+func updateCacheArgs(args map[string]interface{}, params *manifests.ConfigParams) (int, error) {
+	var updated int
+	var err error
+
+	if params.Cache != nil {
+		if params.Cache.ResyncMethod != nil {
+			resyncMethod := *params.Cache.ResyncMethod // shortcut
+			err = manifests.ValidateCacheResyncMethod(resyncMethod)
+			if err != nil {
+				return updated, err
+			}
+			err = unstructured.SetNestedField(args, resyncMethod, "resyncMethod")
+			if err != nil {
+				return updated, err
+			}
+			updated++
+		}
+		if params.Cache.ForeignPodsDetectMode != nil {
+			foreignPodsMode := *params.Cache.ForeignPodsDetectMode // shortcut
+			err = manifests.ValidateForeignPodsDetectMode(foreignPodsMode)
+			if err != nil {
+				return updated, err
+			}
+			err = unstructured.SetNestedField(args, foreignPodsMode, "foreignPodsDetect")
+			if err != nil {
+				return updated, err
+			}
+			updated++
+		}
+	}
+
+	return updated, nil
 }
 
 func ensureBackwardCompatibility(args map[string]interface{}) error {

--- a/pkg/objectupdate/sched/render_test.go
+++ b/pkg/objectupdate/sched/render_test.go
@@ -213,6 +213,182 @@ profiles:
 `,
 			expectedUpdate: true,
 		},
+		{
+			name: "all params updated from empty",
+			params: &manifests.ConfigParams{
+				Cache: &manifests.ConfigCacheParams{
+					ResyncPeriodSeconds:   newInt64(42),
+					ResyncMethod:          newString("OnlyExclusiveResources"),
+					ForeignPodsDetectMode: newString("OnlyExclusiveResources"),
+				},
+			},
+			initial: configTemplateEmpty,
+			expected: `apiVersion: kubescheduler.config.k8s.io/v1beta3
+kind: KubeSchedulerConfiguration
+leaderElection:
+  leaderElect: false
+profiles:
+- pluginConfig:
+  - args:
+      cache:
+        foreignPodsDetect: OnlyExclusiveResources
+        resyncMethod: OnlyExclusiveResources
+      cacheResyncPeriodSeconds: 42
+    name: NodeResourceTopologyMatch
+  plugins:
+    filter:
+      enabled:
+      - name: NodeResourceTopologyMatch
+    reserve:
+      enabled:
+      - name: NodeResourceTopologyMatch
+    score:
+      enabled:
+      - name: NodeResourceTopologyMatch
+  schedulerName: test-sched-name
+`,
+			expectedUpdate: true,
+		},
+		{
+			name: "cache params updated from empty",
+			params: &manifests.ConfigParams{
+				Cache: &manifests.ConfigCacheParams{
+					ResyncPeriodSeconds:   newInt64(11),
+					ResyncMethod:          newString("OnlyExclusiveResources"),
+					ForeignPodsDetectMode: newString("OnlyExclusiveResources"),
+				},
+			},
+			initial: configTemplateAllValues,
+			expected: `apiVersion: kubescheduler.config.k8s.io/v1beta3
+kind: KubeSchedulerConfiguration
+leaderElection:
+  leaderElect: false
+profiles:
+- pluginConfig:
+  - args:
+      cache:
+        foreignPodsDetect: OnlyExclusiveResources
+        resyncMethod: OnlyExclusiveResources
+      cacheResyncPeriodSeconds: 11
+    name: NodeResourceTopologyMatch
+  plugins:
+    filter:
+      enabled:
+      - name: NodeResourceTopologyMatch
+    reserve:
+      enabled:
+      - name: NodeResourceTopologyMatch
+    score:
+      enabled:
+      - name: NodeResourceTopologyMatch
+  schedulerName: test-sched-name
+`,
+			expectedUpdate: true,
+		},
+		{
+			name: "all params updated from nonempty",
+			params: &manifests.ConfigParams{
+				Cache: &manifests.ConfigCacheParams{
+					ResyncPeriodSeconds:   newInt64(7),
+					ResyncMethod:          newString("Autodetect"),
+					ForeignPodsDetectMode: newString("None"),
+				},
+			},
+			initial: configTemplateAllValuesFineTuned,
+			expected: `apiVersion: kubescheduler.config.k8s.io/v1beta3
+kind: KubeSchedulerConfiguration
+leaderElection:
+  leaderElect: false
+profiles:
+- pluginConfig:
+  - args:
+      cache:
+        foreignPodsDetect: None
+        resyncMethod: Autodetect
+      cacheResyncPeriodSeconds: 7
+    name: NodeResourceTopologyMatch
+  plugins:
+    filter:
+      enabled:
+      - name: NodeResourceTopologyMatch
+    reserve:
+      enabled:
+      - name: NodeResourceTopologyMatch
+    score:
+      enabled:
+      - name: NodeResourceTopologyMatch
+  schedulerName: test-sched-name
+`,
+			expectedUpdate: true,
+		},
+		{
+			name: "partial cache params updated from empty",
+			params: &manifests.ConfigParams{
+				Cache: &manifests.ConfigCacheParams{
+					ResyncPeriodSeconds:   newInt64(42),
+					ForeignPodsDetectMode: newString("None"),
+				},
+			},
+			initial: configTemplateEmpty,
+			expected: `apiVersion: kubescheduler.config.k8s.io/v1beta3
+kind: KubeSchedulerConfiguration
+leaderElection:
+  leaderElect: false
+profiles:
+- pluginConfig:
+  - args:
+      cache:
+        foreignPodsDetect: None
+      cacheResyncPeriodSeconds: 42
+    name: NodeResourceTopologyMatch
+  plugins:
+    filter:
+      enabled:
+      - name: NodeResourceTopologyMatch
+    reserve:
+      enabled:
+      - name: NodeResourceTopologyMatch
+    score:
+      enabled:
+      - name: NodeResourceTopologyMatch
+  schedulerName: test-sched-name
+`,
+			expectedUpdate: true,
+		},
+		{
+			name: "partial params updated from nonempty",
+			params: &manifests.ConfigParams{
+				Cache: &manifests.ConfigCacheParams{
+					ForeignPodsDetectMode: newString("All"),
+				},
+			},
+			initial: configTemplateAllValuesFineTuned,
+			expected: `apiVersion: kubescheduler.config.k8s.io/v1beta3
+kind: KubeSchedulerConfiguration
+leaderElection:
+  leaderElect: false
+profiles:
+- pluginConfig:
+  - args:
+      cache:
+        foreignPodsDetect: All
+        resyncMethod: OnlyExclusiveResources
+      cacheResyncPeriodSeconds: 5
+    name: NodeResourceTopologyMatch
+  plugins:
+    filter:
+      enabled:
+      - name: NodeResourceTopologyMatch
+    reserve:
+      enabled:
+      - name: NodeResourceTopologyMatch
+    score:
+      enabled:
+      - name: NodeResourceTopologyMatch
+  schedulerName: test-sched-name
+`,
+			expectedUpdate: true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -267,6 +443,31 @@ leaderElection:
 profiles:
 - pluginConfig:
   - args:
+      cacheResyncPeriodSeconds: 5
+    name: NodeResourceTopologyMatch
+  plugins:
+    filter:
+      enabled:
+      - name: NodeResourceTopologyMatch
+    reserve:
+      enabled:
+      - name: NodeResourceTopologyMatch
+    score:
+      enabled:
+      - name: NodeResourceTopologyMatch
+  schedulerName: test-sched-name
+`
+
+var configTemplateAllValuesFineTuned string = `apiVersion: kubescheduler.config.k8s.io/v1beta3
+kind: KubeSchedulerConfiguration
+leaderElection:
+  leaderElect: false
+profiles:
+- pluginConfig:
+  - args:
+      cache:
+        foreignPodsDetect: OnlyExclusiveResources
+        resyncMethod: OnlyExclusiveResources
       cacheResyncPeriodSeconds: 5
     name: NodeResourceTopologyMatch
   plugins:
@@ -341,5 +542,9 @@ profiles:
 `
 
 func newInt64(value int64) *int64 {
+	return &value
+}
+
+func newString(value string) *string {
 	return &value
 }


### PR DESCRIPTION
Add support to gather and set cache fine-tuning parameters:
ForeignPodsDetectMode and CacheResyncMethod, both exposed
in the `cache` subfield of the plugin parameters (at least
cacheResyncPeriodSeconds also belong there, but this is
another story for another day).

Also add validation support for the parameters.