### PR TITLE
e2e: relax running timeout

### DIFF
--- a/test/e2e/manifests.go
+++ b/test/e2e/manifests.go
@@ -19,6 +19,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/go-logr/logr"
 
@@ -139,7 +140,7 @@ var _ = ginkgo.Describe("[ManifestFlow] Deployer rendering", func() {
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 				ginkgo.By("checking the pod goes running")
-				e2epods.WaitForPodToBeRunning(cli, testPod.Namespace, testPod.Name)
+				e2epods.WaitForPodToBeRunning(cli, testPod.Namespace, testPod.Name, 2*time.Minute)
 			})
 		})
 	})

--- a/test/e2e/positive.go
+++ b/test/e2e/positive.go
@@ -331,7 +331,7 @@ var _ = ginkgo.Describe("[PositiveFlow] Deployer execution", func() {
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 				ginkgo.By("checking the pod goes running")
-				e2epods.WaitForPodToBeRunning(cli, testPod.Namespace, testPod.Name)
+				e2epods.WaitForPodToBeRunning(cli, testPod.Namespace, testPod.Name, 2*time.Minute)
 			})
 		})
 
@@ -426,9 +426,8 @@ var _ = ginkgo.Describe("[PositiveFlow] Deployer execution", func() {
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 				ginkgo.By("checking the pod goes running")
-				e2epods.WaitForPodToBeRunning(cli, testPod.Namespace, testPod.Name)
+				e2epods.WaitForPodToBeRunning(cli, testPod.Namespace, testPod.Name, 2*time.Minute)
 			})
-
 		})
 	})
 })


### PR DESCRIPTION
The test
```
[PositiveFlow] Deployer execution with a running cluster without any components
  when deployed with resource-topology-exporter as the updater [It] should verify
  a test pod scheduled with the topology aware scheduler goes running
```

started to flake lately with the symptoms matching a timeout due to slow CI.
Relax the timeout and add more logs to (try to) deflake the issue.