### PR TITLE
pkg: rte: address verbosity flag properly

### DIFF
--- a/pkg/objectupdate/rte/rte.go
+++ b/pkg/objectupdate/rte/rte.go
@@ -123,7 +123,7 @@ func DaemonSet(ds *appsv1.DaemonSet, plat platform.Platform, configMapName strin
 		}
 
 		flags := flagcodec.ParseArgvKeyValue(cntSpec.Args)
-		flags.SetOption("-v", fmt.Sprintf("%d", opts.Verbose))
+		flags.SetOption("--v", fmt.Sprintf("%d", opts.Verbose))
 		if opts.UpdateInterval > 0 {
 			flags.SetOption("--sleep-interval", fmt.Sprintf("%v", opts.UpdateInterval))
 		} else {


### PR DESCRIPTION
Follow the convention used in NROP repo to address container args with two "-".  -v is never actually updated while --v is. Keep the convention and use it like "--v".