### PR TITLE
[release-0.18][manual] rte: selinux: support for OCP up to 4.15

### DIFF
--- a/pkg/assets/selinux/assets.go
+++ b/pkg/assets/selinux/assets.go
@@ -19,6 +19,8 @@ const (
 	// TODO: demote public constant here once we can remove from the public API
 	ocpVersion412 = "v4.12"
 	ocpVersion413 = "v4.13"
+	ocpVersion414 = "v4.14"
+	ocpVersion415 = "v4.15"
 )
 
 //go:embed selinuxinstall.service.template
@@ -29,7 +31,8 @@ var policy embed.FS
 
 func GetPolicy(ver platform.Version) ([]byte, error) {
 	// keep it ordered from most recent supported to the oldest supported
-	for _, cand := range []string{ocpVersion413, ocpVersion412, OCPVersion411, ocpVersion410} {
+	allVersions := knownVersions()
+	for _, cand := range allVersions {
 		// error should never happen: we control the input here
 		ok, err := ver.AtLeastString(cand)
 		if err != nil {
@@ -41,6 +44,17 @@ func GetPolicy(ver platform.Version) ([]byte, error) {
 	}
 	// just in case we end up here first supported version is 4.10, hence this is a safe fallback
 	return policy.ReadFile(policyPathFromVer(ocpVersion410))
+}
+
+func knownVersions() []string {
+	return []string{
+		ocpVersion415,
+		ocpVersion414,
+		ocpVersion413,
+		ocpVersion412,
+		ocpVersion411,
+		ocpVersion410,
+	}
 }
 
 func policyPathFromVer(ver string) string {

--- a/pkg/assets/selinux/assets_test.go
+++ b/pkg/assets/selinux/assets_test.go
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 Red Hat, Inc.
+ */
+
+package selinux
+
+import (
+	"testing"
+
+	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
+)
+
+func TestGetPolicy(t *testing.T) {
+	type testCase struct {
+		name          string
+		ver           platform.Version
+		expectedError bool
+	}
+
+	testCases := []testCase{
+		{
+			name:          "supported",
+			ver:           platform.Version("v4.12"),
+			expectedError: false,
+		},
+		{
+			name:          "more recent",
+			ver:           platform.Version("v4.99"),
+			expectedError: false,
+		},
+		{
+			name:          "too old",
+			ver:           platform.Version("v3.11"),
+			expectedError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := GetPolicy(tc.ver)
+			gotErr := (err != nil)
+			if gotErr != tc.expectedError {
+				t.Fatalf("GetPolicy(%v) unexpected result: expected error %v got %v", tc.ver, tc.expectedError, gotErr)
+			}
+		})
+	}
+}

--- a/pkg/assets/selinux/policy/ocp_v4.14.cil
+++ b/pkg/assets/selinux/policy/ocp_v4.14.cil
@@ -1,0 +1,25 @@
+(block rte
+	(type process)
+	(roletype system_r process)
+	(typeattributeset domain (process))
+	;
+	; Giving rte.process the same attributes as container_t
+	(typeattributeset container_domain (process))
+	(typeattributeset container_net_domain (process))
+	(typeattributeset svirt_sandbox_domain (process))
+	(typeattributeset sandbox_net_domain (process))
+	; MCS is leveraged by container_t and others, like us, to prevent cross-pod communication.
+	(typeattributeset mcs_constrained_type (process))
+	;
+	; Allow access to procfs (also needed by libraries)
+	(allow process proc_type (file (open read)))
+	;
+	; Allow to RTE pod access to /run/rte directory
+	(allow process container_var_run_t (dir (add_name write)))
+	(allow process container_var_run_t (file (create read write open)))
+	;
+	; Allow to RTE pod connect, read and write permissions to /var/lib/kubelet/pod-resource/kubelet.sock
+	(allow process container_var_lib_t (sock_file (open getattr read write ioctl lock append)))
+	(allow process container_var_lib_t (unix_stream_socket (connectto)))
+	(allow process unconfined_service_t (unix_stream_socket (connectto)))
+)

--- a/pkg/assets/selinux/policy/ocp_v4.15.cil
+++ b/pkg/assets/selinux/policy/ocp_v4.15.cil
@@ -1,0 +1,25 @@
+(block rte
+	(type process)
+	(roletype system_r process)
+	(typeattributeset domain (process))
+	;
+	; Giving rte.process the same attributes as container_t
+	(typeattributeset container_domain (process))
+	(typeattributeset container_net_domain (process))
+	(typeattributeset svirt_sandbox_domain (process))
+	(typeattributeset sandbox_net_domain (process))
+	; MCS is leveraged by container_t and others, like us, to prevent cross-pod communication.
+	(typeattributeset mcs_constrained_type (process))
+	;
+	; Allow access to procfs (also needed by libraries)
+	(allow process proc_type (file (open read)))
+	;
+	; Allow to RTE pod access to /run/rte directory
+	(allow process container_var_run_t (dir (add_name write)))
+	(allow process container_var_run_t (file (create read write open)))
+	;
+	; Allow to RTE pod connect, read and write permissions to /var/lib/kubelet/pod-resource/kubelet.sock
+	(allow process container_var_lib_t (sock_file (open getattr read write ioctl lock append)))
+	(allow process container_var_lib_t (unix_stream_socket (connectto)))
+	(allow process kubelet_t (unix_stream_socket (connectto)))
+)


### PR DESCRIPTION
4.14 is identical to 4.13, but changes are needed for 4.15

partial backport of #260 