### PR TITLE
[release-0.18][manual] selinux policy: refine process contexts

### DIFF
--- a/pkg/assets/selinux/policy/ocp_v4.14.cil
+++ b/pkg/assets/selinux/policy/ocp_v4.14.cil
@@ -21,5 +21,5 @@
 	; Allow to RTE pod connect, read and write permissions to /var/lib/kubelet/pod-resource/kubelet.sock
 	(allow process container_var_lib_t (sock_file (open getattr read write ioctl lock append)))
 	(allow process container_var_lib_t (unix_stream_socket (connectto)))
-	(allow process unconfined_service_t (unix_stream_socket (connectto)))
+	(allow process kubelet_t (unix_stream_socket (connectto)))
 )

--- a/pkg/assets/selinux/policy/ocp_v4.15.cil
+++ b/pkg/assets/selinux/policy/ocp_v4.15.cil
@@ -20,6 +20,5 @@
 	;
 	; Allow to RTE pod connect, read and write permissions to /var/lib/kubelet/pod-resource/kubelet.sock
 	(allow process container_var_lib_t (sock_file (open getattr read write ioctl lock append)))
-	(allow process container_var_lib_t (unix_stream_socket (connectto)))
 	(allow process kubelet_t (unix_stream_socket (connectto)))
 )


### PR DESCRIPTION
updates to selinux policies for OCP 4.14 and 4.15. Fix expected process context and minimize the permission list.