### PR TITLE
selinux: more policy cleanups

### DIFF
--- a/pkg/assets/selinux/assets_test.go
+++ b/pkg/assets/selinux/assets_test.go
@@ -31,6 +31,11 @@ func TestGetPolicy(t *testing.T) {
 
 	testCases := []testCase{
 		{
+			name:          "latest", // at time of writing. Keep me updated!
+			ver:           platform.Version("v4.16"),
+			expectedError: false,
+		},
+		{
 			name:          "supported",
 			ver:           platform.Version("v4.12"),
 			expectedError: false,

--- a/pkg/assets/selinux/policy/ocp_v4.14.cil
+++ b/pkg/assets/selinux/policy/ocp_v4.14.cil
@@ -20,6 +20,5 @@
 	;
 	; Allow to RTE pod connect, read and write permissions to /var/lib/kubelet/pod-resource/kubelet.sock
 	(allow process container_var_lib_t (sock_file (open getattr read write ioctl lock append)))
-	(allow process container_var_lib_t (unix_stream_socket (connectto)))
 	(allow process kubelet_t (unix_stream_socket (connectto)))
 )

--- a/pkg/assets/selinux/policy/ocp_v4.16.cil
+++ b/pkg/assets/selinux/policy/ocp_v4.16.cil
@@ -1,0 +1,24 @@
+(block rte
+	(type process)
+	(roletype system_r process)
+	(typeattributeset domain (process))
+	;
+	; Giving rte.process the same attributes as container_t
+	(typeattributeset container_domain (process))
+	(typeattributeset container_net_domain (process))
+	(typeattributeset svirt_sandbox_domain (process))
+	(typeattributeset sandbox_net_domain (process))
+	; MCS is leveraged by container_t and others, like us, to prevent cross-pod communication.
+	(typeattributeset mcs_constrained_type (process))
+	;
+	; Allow access to procfs (also needed by libraries)
+	(allow process proc_type (file (open read)))
+	;
+	; Allow to RTE pod access to /run/rte directory
+	(allow process container_var_run_t (dir (add_name write)))
+	(allow process container_var_run_t (file (create read write open)))
+	;
+	; Allow to RTE pod connect, read and write permissions to /var/lib/kubelet/pod-resource/kubelet.sock
+	(allow process container_var_lib_t (sock_file (open getattr read write ioctl lock append)))
+	(allow process kubelet_t (unix_stream_socket (connectto)))
+)


### PR DESCRIPTION
add more policy cleanups for recent OCPs, and add a command to easily inspect the proposed policy.