### PR TITLE
config: don't check or use FeatureGate

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,6 @@ kubeadmConfigPatches:
   cpuManagerPolicy: "static"
   topologyManagerPolicy: "single-numa-node"
   reservedSystemCPUs: "0,16"
-  featureGates:
-    KubeletPodResourcesGetAllocatable: true
 nodes:
 - role: control-plane
 - role: worker
@@ -158,8 +156,6 @@ kubeadmConfigPatches:
   cpuManagerPolicy: "static"
   topologyManagerPolicy: "single-numa-node"
   reservedSystemCPUs: "0,16"
-  featureGates:
-    KubeletPodResourcesGetAllocatable: true
 nodes:
 - role: control-plane
 - role: worker

--- a/hack/kind-config-e2e-positive.yaml
+++ b/hack/kind-config-e2e-positive.yaml
@@ -17,8 +17,6 @@ kubeadmConfigPatches:
         memory: "612Mi"
   systemReserved: 
     memory: "256Mi"
-  featureGates:
-    KubeletPodResourcesGetAllocatable: true
 nodes:
 - role: control-plane
 - role: worker

--- a/pkg/validator/kubeletconfig.go
+++ b/pkg/validator/kubeletconfig.go
@@ -42,10 +42,9 @@ const (
 )
 
 const (
-	ExpectedPodResourcesFeatureGate = "KubeletPodResourcesGetAllocatable"
-	ExpectedCPUManagerPolicy        = "static"
-	ExpectedMemoryManagerPolicy     = kubeletconfigv1beta1.StaticMemoryManagerPolicy
-	ExpectedTopologyManagerPolicy   = kubeletconfigv1beta1.SingleNumaNodeTopologyManagerPolicy
+	ExpectedCPUManagerPolicy      = "static"
+	ExpectedMemoryManagerPolicy   = kubeletconfigv1beta1.StaticMemoryManagerPolicy
+	ExpectedTopologyManagerPolicy = kubeletconfigv1beta1.SingleNumaNodeTopologyManagerPolicy
 )
 
 const (
@@ -110,30 +109,6 @@ func ValidateClusterNodeKubeletConfig(nodeName string, nodeVersion *version.Info
 			Detected: "no configuration",
 		})
 		return vrs
-	}
-
-	if needCheckFeatureGates(nodeVersion) {
-		if kubeletConf.FeatureGates == nil {
-			vrs = append(vrs, ValidationResult{
-				Node:      nodeName,
-				Area:      AreaKubelet,
-				Component: ComponentFeatureGates,
-				/* no specific Setting: all are missing! */
-				Expected: "present",
-				Detected: "missing data",
-			})
-		} else {
-			if enabled := kubeletConf.FeatureGates[ExpectedPodResourcesFeatureGate]; !enabled {
-				vrs = append(vrs, ValidationResult{
-					Node:      nodeName,
-					Area:      AreaKubelet,
-					Component: ComponentFeatureGates,
-					Setting:   ExpectedPodResourcesFeatureGate,
-					Expected:  "enabled",
-					Detected:  "disabled",
-				})
-			}
-		}
 	}
 
 	if kubeletConf.CPUManagerPolicy != ExpectedCPUManagerPolicy {
@@ -202,17 +177,4 @@ func ValidateClusterNodeKubeletConfig(nodeName string, nodeVersion *version.Info
 		})
 	}
 	return vrs
-}
-
-func needCheckFeatureGates(nodeVersion *version.Info) bool {
-	if nodeVersion == nil {
-		// we don't know, we don't take any risk
-		return true
-	}
-	if nodeVersion.GitVersion == "" {
-		// ditto
-		return true
-	}
-	ok, _ := isAPIVersionAtLeast(nodeVersion.GitVersion, kubeMinVersionGetAllocatable)
-	return !ok // note NOT
 }

--- a/pkg/validator/kubeletconfig_test.go
+++ b/pkg/validator/kubeletconfig_test.go
@@ -56,11 +56,6 @@ func TestKubeletValidations(t *testing.T) {
 				{
 					Node:      nodeName,
 					Area:      AreaKubelet,
-					Component: ComponentFeatureGates,
-				},
-				{
-					Node:      nodeName,
-					Area:      AreaKubelet,
 					Component: ComponentCPUManager,
 					Setting:   "policy",
 				},
@@ -100,9 +95,6 @@ func TestKubeletValidations(t *testing.T) {
 		{
 			name: "correct",
 			kubeletConf: &kubeletconfigv1beta1.KubeletConfiguration{
-				FeatureGates: map[string]bool{
-					ExpectedPodResourcesFeatureGate: true,
-				},
 				CPUManagerPolicy: ExpectedCPUManagerPolicy,
 				CPUManagerReconcilePeriod: metav1.Duration{
 					Duration: 5 * time.Second,
@@ -119,35 +111,8 @@ func TestKubeletValidations(t *testing.T) {
 			expected: []ValidationResult{},
 		},
 		{
-			name: "missing feature gate",
-			kubeletConf: &kubeletconfigv1beta1.KubeletConfiguration{
-				CPUManagerPolicy: ExpectedCPUManagerPolicy,
-				CPUManagerReconcilePeriod: metav1.Duration{
-					Duration: 5 * time.Second,
-				},
-				MemoryManagerPolicy: ExpectedMemoryManagerPolicy,
-				ReservedMemory: []kubeletconfigv1beta1.MemoryReservation{
-					{
-						NumaNode: 1,
-					},
-				},
-				ReservedSystemCPUs:    "0,1",
-				TopologyManagerPolicy: ExpectedTopologyManagerPolicy,
-			},
-			expected: []ValidationResult{
-				{
-					Node:      nodeName,
-					Area:      AreaKubelet,
-					Component: ComponentFeatureGates,
-				},
-			},
-		},
-		{
 			name: "missing topology manager policy",
 			kubeletConf: &kubeletconfigv1beta1.KubeletConfiguration{
-				FeatureGates: map[string]bool{
-					ExpectedPodResourcesFeatureGate: true,
-				},
 				CPUManagerPolicy: ExpectedCPUManagerPolicy,
 				CPUManagerReconcilePeriod: metav1.Duration{
 					Duration: 5 * time.Second,
@@ -172,9 +137,6 @@ func TestKubeletValidations(t *testing.T) {
 		{
 			name: "wrong topology manager policy",
 			kubeletConf: &kubeletconfigv1beta1.KubeletConfiguration{
-				FeatureGates: map[string]bool{
-					ExpectedPodResourcesFeatureGate: true,
-				},
 				CPUManagerPolicy: ExpectedCPUManagerPolicy,
 				CPUManagerReconcilePeriod: metav1.Duration{
 					Duration: 5 * time.Second,
@@ -200,9 +162,6 @@ func TestKubeletValidations(t *testing.T) {
 		{
 			name: "missing cpumanager configuration",
 			kubeletConf: &kubeletconfigv1beta1.KubeletConfiguration{
-				FeatureGates: map[string]bool{
-					ExpectedPodResourcesFeatureGate: true,
-				},
 				MemoryManagerPolicy: ExpectedMemoryManagerPolicy,
 				ReservedMemory: []kubeletconfigv1beta1.MemoryReservation{
 					{
@@ -236,9 +195,6 @@ func TestKubeletValidations(t *testing.T) {
 		{
 			name: "wrong cpumanager reconcile period",
 			kubeletConf: &kubeletconfigv1beta1.KubeletConfiguration{
-				FeatureGates: map[string]bool{
-					ExpectedPodResourcesFeatureGate: true,
-				},
 				CPUManagerPolicy: ExpectedCPUManagerPolicy,
 				CPUManagerReconcilePeriod: metav1.Duration{
 					Duration: 30 * time.Second,
@@ -259,38 +215,6 @@ func TestKubeletValidations(t *testing.T) {
 					Area:      AreaKubelet,
 					Component: ComponentCPUManager,
 					Setting:   "reconcile period",
-				},
-			},
-		},
-		{
-			// CAUTION: I'm not actually sure k8s <= 1.20 had all these
-			// fields in the KubeletConfig, so we're bending the rules a bit here
-			name: "version too old, no feature gate",
-			kubeletConf: &kubeletconfigv1beta1.KubeletConfiguration{
-				FeatureGates:     map[string]bool{},
-				CPUManagerPolicy: ExpectedCPUManagerPolicy,
-				CPUManagerReconcilePeriod: metav1.Duration{
-					Duration: 5 * time.Second,
-				},
-				MemoryManagerPolicy: ExpectedMemoryManagerPolicy,
-				ReservedMemory: []kubeletconfigv1beta1.MemoryReservation{
-					{
-						NumaNode: 1,
-					},
-				},
-				ReservedSystemCPUs:    "0,1",
-				TopologyManagerPolicy: ExpectedTopologyManagerPolicy,
-			},
-			nodeVersion: &version.Info{
-				Major:      "1",
-				Minor:      "20",
-				GitVersion: "v1.20.5",
-			},
-			expected: []ValidationResult{
-				{
-					Node:      nodeName,
-					Area:      AreaKubelet,
-					Component: ComponentFeatureGates,
 				},
 			},
 		},


### PR DESCRIPTION
GetAllocatableResponse's FG matured in recent kubes (around 1.27) so there's no point anymore in checking it.