### PR TITLE
[release-0.16][manual] selinux: align 4.13 policy

### DIFF
--- a/pkg/assets/selinux/policy/ocp_v4.13.cil
+++ b/pkg/assets/selinux/policy/ocp_v4.13.cil
@@ -20,6 +20,5 @@
 	;
 	; Allow to RTE pod connect, read and write permissions to /var/lib/kubelet/pod-resource/kubelet.sock
 	(allow process container_var_lib_t (sock_file (open getattr read write ioctl lock append)))
-	(allow process container_var_lib_t (unix_stream_socket (connectto)))
-	(allow process unconfined_service_t (unix_stream_socket (connectto)))
+	(allow process kubelet_t (unix_stream_socket (connectto)))
 )


### PR DESCRIPTION
the 4.13 policy used to be the odd one, but since
the platform fixed it previous quirks, time to align also our custom policy.