### PR TITLE
golang: toolchain: bump to 1.21

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/setup-go@v3
       id: go
       with:
-        go-version: 1.20.10
+        go-version: 1.21.7
 
     - name: build test binary
       run: |
@@ -60,7 +60,7 @@ jobs:
       uses: actions/setup-go@v3
       id: go
       with:
-        go-version: 1.20.10
+        go-version: 1.21.7
 
     - name: build test binary
       run: |
@@ -96,7 +96,7 @@ jobs:
       uses: actions/setup-go@v3
       id: go
       with:
-        go-version: 1.20.10
+        go-version: 1.21.7
 
     - name: build test binary
       run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,7 @@ jobs:
     - name: set up golang
       uses: actions/setup-go@v3
       with:
-        go-version: 1.20.10
+        go-version: 1.21.7
 
     - name: format
       run: ./hack/check-format.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/setup-go@v3
       id: go
       with:
-        go-version: 1.20.10
+        go-version: 1.21.7
 
     - name: verify modules
       run: go mod verify

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/k8stopologyawareschedwg/deployer
 
-go 1.19
+go 1.20
 
 require (
 	github.com/aquasecurity/go-version v0.0.0-20210121072130-637058cfe492


### PR DESCRIPTION
bump the golang toolchain version
bump the module version, to be able to use new language features