### PR TITLE
[release-0.19] commands: sched: pass through scoringStrategy config

### DIFF
--- a/pkg/commands/deploy.go
+++ b/pkg/commands/deploy.go
@@ -102,14 +102,15 @@ func NewDeploySchedulerPluginCommand(env *deployer.Environment, commonOpts *opti
 
 			env.Log.Info("detection", "platform", commonOpts.ClusterPlatform, "reason", reason, "version", commonOpts.ClusterVersion, "source", source)
 			return sched.Deploy(env, options.Scheduler{
-				Platform:          commonOpts.ClusterPlatform,
-				WaitCompletion:    commonOpts.WaitCompletion,
-				Replicas:          int32(commonOpts.Replicas),
-				PullIfNotPresent:  commonOpts.PullIfNotPresent,
-				ProfileName:       commonOpts.SchedProfileName,
-				CacheResyncPeriod: commonOpts.SchedResyncPeriod,
-				CtrlPlaneAffinity: commonOpts.SchedCtrlPlaneAffinity,
-				Verbose:           commonOpts.SchedVerbose,
+				Platform:               commonOpts.ClusterPlatform,
+				WaitCompletion:         commonOpts.WaitCompletion,
+				Replicas:               int32(commonOpts.Replicas),
+				PullIfNotPresent:       commonOpts.PullIfNotPresent,
+				ProfileName:            commonOpts.SchedProfileName,
+				CacheResyncPeriod:      commonOpts.SchedResyncPeriod,
+				CtrlPlaneAffinity:      commonOpts.SchedCtrlPlaneAffinity,
+				Verbose:                commonOpts.SchedVerbose,
+				ScoringStratConfigData: commonOpts.SchedScoringStratConfigData,
 			})
 		},
 		Args: cobra.NoArgs,

--- a/pkg/commands/remove.go
+++ b/pkg/commands/remove.go
@@ -54,13 +54,15 @@ func NewRemoveCommand(env *deployer.Environment, commonOpts *options.Options) *c
 			env.Log.Info("detection", "platform", commonOpts.ClusterPlatform, "reason", reason, "version", commonOpts.ClusterVersion, "source", source)
 
 			err = sched.Remove(env, options.Scheduler{
-				Platform:          commonOpts.ClusterPlatform,
-				WaitCompletion:    commonOpts.WaitCompletion,
-				Replicas:          int32(commonOpts.Replicas),
-				PullIfNotPresent:  commonOpts.PullIfNotPresent,
-				ProfileName:       commonOpts.SchedProfileName,
-				CacheResyncPeriod: commonOpts.SchedResyncPeriod,
-				CtrlPlaneAffinity: commonOpts.SchedCtrlPlaneAffinity,
+				Platform:               commonOpts.ClusterPlatform,
+				WaitCompletion:         commonOpts.WaitCompletion,
+				Replicas:               int32(commonOpts.Replicas),
+				PullIfNotPresent:       commonOpts.PullIfNotPresent,
+				ProfileName:            commonOpts.SchedProfileName,
+				CacheResyncPeriod:      commonOpts.SchedResyncPeriod,
+				CtrlPlaneAffinity:      commonOpts.SchedCtrlPlaneAffinity,
+				Verbose:                commonOpts.SchedVerbose,
+				ScoringStratConfigData: commonOpts.SchedScoringStratConfigData,
 			})
 			if err != nil {
 				// intentionally keep going to remove as much as possible
@@ -153,14 +155,15 @@ func NewRemoveSchedulerPluginCommand(env *deployer.Environment, commonOpts *opti
 
 			env.Log.Info("detection", "platform", commonOpts.ClusterPlatform, "reason", reason, "version", commonOpts.ClusterVersion, "source", source)
 			return sched.Remove(env, options.Scheduler{
-				Platform:          commonOpts.ClusterPlatform,
-				WaitCompletion:    commonOpts.WaitCompletion,
-				Replicas:          int32(commonOpts.Replicas),
-				PullIfNotPresent:  commonOpts.PullIfNotPresent,
-				ProfileName:       commonOpts.SchedProfileName,
-				CacheResyncPeriod: commonOpts.SchedResyncPeriod,
-				CtrlPlaneAffinity: commonOpts.SchedCtrlPlaneAffinity,
-				Verbose:           commonOpts.SchedVerbose,
+				Platform:               commonOpts.ClusterPlatform,
+				WaitCompletion:         commonOpts.WaitCompletion,
+				Replicas:               int32(commonOpts.Replicas),
+				PullIfNotPresent:       commonOpts.PullIfNotPresent,
+				ProfileName:            commonOpts.SchedProfileName,
+				CacheResyncPeriod:      commonOpts.SchedResyncPeriod,
+				CtrlPlaneAffinity:      commonOpts.SchedCtrlPlaneAffinity,
+				Verbose:                commonOpts.SchedVerbose,
+				ScoringStratConfigData: commonOpts.SchedScoringStratConfigData,
 			})
 		},
 		Args: cobra.NoArgs,

--- a/pkg/commands/render.go
+++ b/pkg/commands/render.go
@@ -176,12 +176,13 @@ func RenderManifests(env *deployer.Environment, commonOpts *options.Options) err
 	}
 
 	schedRenderOpts := options.Scheduler{
-		Replicas:          int32(commonOpts.Replicas),
-		PullIfNotPresent:  commonOpts.PullIfNotPresent,
-		ProfileName:       commonOpts.SchedProfileName,
-		CacheResyncPeriod: commonOpts.SchedResyncPeriod,
-		CtrlPlaneAffinity: commonOpts.SchedCtrlPlaneAffinity,
-		Verbose:           commonOpts.SchedVerbose,
+		Replicas:               int32(commonOpts.Replicas),
+		PullIfNotPresent:       commonOpts.PullIfNotPresent,
+		ProfileName:            commonOpts.SchedProfileName,
+		CacheResyncPeriod:      commonOpts.SchedResyncPeriod,
+		CtrlPlaneAffinity:      commonOpts.SchedCtrlPlaneAffinity,
+		Verbose:                commonOpts.SchedVerbose,
+		ScoringStratConfigData: commonOpts.SchedScoringStratConfigData,
 	}
 
 	schedObjs, err := schedManifests.Render(env.Log, schedRenderOpts)

--- a/pkg/deploy/cluster.go
+++ b/pkg/deploy/cluster.go
@@ -61,14 +61,15 @@ func OnCluster(env *deployer.Environment, commonOpts *options.Options) error {
 		return err
 	}
 	if err := sched.Deploy(env, options.Scheduler{
-		Platform:          commonOpts.ClusterPlatform,
-		WaitCompletion:    commonOpts.WaitCompletion,
-		Replicas:          int32(commonOpts.Replicas),
-		PullIfNotPresent:  commonOpts.PullIfNotPresent,
-		ProfileName:       commonOpts.SchedProfileName,
-		CacheResyncPeriod: commonOpts.SchedResyncPeriod,
-		CtrlPlaneAffinity: commonOpts.SchedCtrlPlaneAffinity,
-		Verbose:           commonOpts.SchedVerbose,
+		Platform:               commonOpts.ClusterPlatform,
+		WaitCompletion:         commonOpts.WaitCompletion,
+		Replicas:               int32(commonOpts.Replicas),
+		PullIfNotPresent:       commonOpts.PullIfNotPresent,
+		ProfileName:            commonOpts.SchedProfileName,
+		CacheResyncPeriod:      commonOpts.SchedResyncPeriod,
+		CtrlPlaneAffinity:      commonOpts.SchedCtrlPlaneAffinity,
+		Verbose:                commonOpts.SchedVerbose,
+		ScoringStratConfigData: commonOpts.SchedScoringStratConfigData,
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
We need to pass the data in all the flows,
not just on the render flow.

Signed-off-by: Francesco Romani <fromani@redhat.com>
(cherry picked from commit ffdce3e646a53ff756482ca9943891554981c275)