### PR TITLE
images: overhaul package, fix environment override

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,10 @@ test-e2e-positive: build-e2e
 test-e2e-negative: build-e2e
 	_out/e2e.test -ginkgo.focus='\[NegativeFlow\]'
 
+.PHONY: test-e2e-local
+test-e2e-local: build-e2e
+	_out/e2e.test -ginkgo.focus='\[Local\]'
+
 .PHONY: gofmt
 gofmt:
 	@echo "Running gofmt"

--- a/pkg/commands/images.go
+++ b/pkg/commands/images.go
@@ -22,7 +22,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer"
-	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/updaters"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/images"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/options"
 )
@@ -39,13 +38,12 @@ func NewImagesCommand(env *deployer.Environment, commonOpts *options.Options) *c
 		Use:   "images",
 		Short: "dump the container images used to deploy",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			images.SetDefaults(opts.useSHA)
-			updaterImage := getUpdaterImage(commonOpts.UpdaterType)
+			imgs := images.GetWithFunc(opts.useSHA, os.LookupEnv)
 			fk := images.FormatText
 			if opts.jsonOutput {
 				fk = images.FormatJSON
 			}
-			imo := images.NewOutput(updaterImage)
+			imo := images.NewOutput(imgs, commonOpts.UpdaterType)
 			var of images.Formatter = imo
 			if opts.rawOutput {
 				of = imo.ToList()
@@ -59,11 +57,4 @@ func NewImagesCommand(env *deployer.Environment, commonOpts *options.Options) *c
 	images.Flags().BoolVarP(&opts.rawOutput, "raw", "r", false, "output raw list. Default is key=value object.")
 	images.Flags().BoolVarP(&opts.useSHA, "sha", "S", false, "emit SHA256 pullspects, not tag pullspecs.")
 	return images
-}
-
-func getUpdaterImage(updaterType string) string {
-	if updaterType == updaters.RTE {
-		return images.ResourceTopologyExporterImage
-	}
-	return images.NodeFeatureDiscoveryImage
 }

--- a/pkg/images/consts_test.go
+++ b/pkg/images/consts_test.go
@@ -19,17 +19,18 @@ package images
 import "testing"
 
 func TestImageURISanity(t *testing.T) {
+	imgs := Get()
 	// TODO: check these are valid pullSpecs
-	if SchedulerPluginSchedulerImage == "" {
+	if imgs.SchedulerPluginScheduler == "" {
 		t.Fatalf("invalid Scheduler Plugin Scheduler Image pull URL")
 	}
-	if SchedulerPluginControllerImage == "" {
+	if imgs.SchedulerPluginController == "" {
 		t.Fatalf("invalid Scheduler Plugin Controller Image pull URL")
 	}
-	if ResourceTopologyExporterImage == "" {
+	if imgs.ResourceTopologyExporter == "" {
 		t.Fatalf("invalid Resource Topology Exporter Image pull URL")
 	}
-	if NodeFeatureDiscoveryImage == "" {
+	if imgs.NodeFeatureDiscovery == "" {
 		t.Fatalf("invalid Node Feature Discovery Image pull URL")
 	}
 }

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -18,44 +18,48 @@ package images
 
 import "os"
 
-func init() {
-	_, ok := os.LookupEnv("TAS_IMAGES_USE_SHA")
-	SetDefaults(ok)
-	Setup(os.LookupEnv)
+type Images struct {
+	SchedulerPluginScheduler  string
+	SchedulerPluginController string
+	ResourceTopologyExporter  string
+	NodeFeatureDiscovery      string
 }
 
-func SetDefaults(useSHA bool) {
+func Defaults(useSHA bool) Images {
 	if useSHA {
-		SchedulerPluginSchedulerImage = SchedulerPluginSchedulerDefaultImageSHA
-		SchedulerPluginControllerImage = SchedulerPluginControllerDefaultImageSHA
-		ResourceTopologyExporterImage = ResourceTopologyExporterDefaultImageSHA
-		NodeFeatureDiscoveryImage = NodeFeatureDiscoveryDefaultImageSHA
-	} else {
-		SchedulerPluginSchedulerImage = SchedulerPluginSchedulerDefaultImageTag
-		SchedulerPluginControllerImage = SchedulerPluginControllerDefaultImageTag
-		ResourceTopologyExporterImage = ResourceTopologyExporterDefaultImageTag
-		NodeFeatureDiscoveryImage = NodeFeatureDiscoveryDefaultImageTag
+		return Images{
+			SchedulerPluginScheduler:  SchedulerPluginSchedulerDefaultImageSHA,
+			SchedulerPluginController: SchedulerPluginControllerDefaultImageSHA,
+			ResourceTopologyExporter:  ResourceTopologyExporterDefaultImageSHA,
+			NodeFeatureDiscovery:      NodeFeatureDiscoveryDefaultImageSHA,
+		}
+	}
+	return Images{
+		SchedulerPluginScheduler:  SchedulerPluginSchedulerDefaultImageTag,
+		SchedulerPluginController: SchedulerPluginControllerDefaultImageTag,
+		ResourceTopologyExporter:  ResourceTopologyExporterDefaultImageTag,
+		NodeFeatureDiscovery:      NodeFeatureDiscoveryDefaultImageTag,
 	}
 }
 
-func Setup(getImage func(string) (string, bool)) {
+func Get() Images {
+	_, ok := os.LookupEnv("TAS_IMAGES_USE_SHA")
+	return GetWithFunc(ok, os.LookupEnv)
+}
+
+func GetWithFunc(useSHA bool, getImage func(string) (string, bool)) Images {
+	images := Defaults(useSHA)
 	if schedImage, ok := getImage("TAS_SCHEDULER_PLUGIN_IMAGE"); ok {
-		SchedulerPluginSchedulerImage = schedImage
+		images.SchedulerPluginScheduler = schedImage
 	}
 	if schedCtrlImage, ok := getImage("TAS_SCHEDULER_PLUGIN_CONTROLLER_IMAGE"); ok {
-		SchedulerPluginControllerImage = schedCtrlImage
+		images.SchedulerPluginController = schedCtrlImage
 	}
 	if rteImage, ok := getImage("TAS_RESOURCE_EXPORTER_IMAGE"); ok {
-		ResourceTopologyExporterImage = rteImage
+		images.ResourceTopologyExporter = rteImage
 	}
 	if nfdImage, ok := getImage("TAS_NODE_FEATURE_DISCOVERY_IMAGE"); ok {
-		NodeFeatureDiscoveryImage = nfdImage
+		images.NodeFeatureDiscovery = nfdImage
 	}
+	return images
 }
-
-var (
-	SchedulerPluginSchedulerImage  = SchedulerPluginSchedulerDefaultImageTag
-	SchedulerPluginControllerImage = SchedulerPluginControllerDefaultImageTag
-	ResourceTopologyExporterImage  = ResourceTopologyExporterDefaultImageTag
-	NodeFeatureDiscoveryImage      = NodeFeatureDiscoveryDefaultImageTag
-)

--- a/pkg/images/output.go
+++ b/pkg/images/output.go
@@ -24,17 +24,22 @@ import (
 	"strings"
 )
 
+const (
+	RTE string = "RTE"
+	NFD string = "NFD"
+)
+
 type Output struct {
 	TopologyUpdater     string `json:"topology_updater"`
 	SchedulerPlugin     string `json:"scheduler_plugin"`
 	SchedulerController string `json:"scheduler_controller"`
 }
 
-func NewOutput(updaterImage string) Output {
+func NewOutput(imgs Images, updaterType string) Output {
 	imo := Output{
-		SchedulerPlugin:     SchedulerPluginSchedulerImage,
-		SchedulerController: SchedulerPluginControllerImage,
-		TopologyUpdater:     updaterImage,
+		SchedulerPlugin:     imgs.SchedulerPluginScheduler,
+		SchedulerController: imgs.SchedulerPluginController,
+		TopologyUpdater:     getUpdaterImage(imgs, updaterType),
 	}
 	return imo
 }
@@ -90,4 +95,11 @@ func (imo Output) Format(kind int, w io.Writer) {
 	} else {
 		imo.EncodeText(w)
 	}
+}
+
+func getUpdaterImage(imgs Images, updaterType string) string {
+	if updaterType == RTE {
+		return imgs.ResourceTopologyExporter
+	}
+	return imgs.NodeFeatureDiscovery
 }

--- a/pkg/images/output_test.go
+++ b/pkg/images/output_test.go
@@ -23,9 +23,9 @@ import (
 )
 
 func TestOutputBasics(t *testing.T) {
-	Setup(testGetImage)
+	imgs := GetWithFunc(false, testGetImage)
 
-	imo := NewOutput("foobar")
+	imo := NewOutput(imgs, "foobar")
 	images := imo.ToList()
 	if len(images) != 3 {
 		t.Errorf("unexpected image list content: %#v", images)
@@ -34,44 +34,44 @@ func TestOutputBasics(t *testing.T) {
 
 func TestOutput(t *testing.T) {
 	type testCase struct {
-		name         string
-		kind         int
-		updaterImage string
-		expected     string
+		name        string
+		kind        int
+		updaterType string
+		expected    string
 	}
 
 	testCases := []testCase{
 		{
-			name:         "text/rte",
-			kind:         FormatText,
-			updaterImage: ResourceTopologyExporterImage,
-			expected:     "TAS_SCHEDULER_PLUGIN_IMAGE=sched_sched\nTAS_SCHEDULER_PLUGIN_CONTROLLER_IMAGE=sched_ctrl\nTAS_RESOURCE_EXPORTER_IMAGE=rte",
+			name:        "text/rte",
+			kind:        FormatText,
+			updaterType: "RTE",
+			expected:    "TAS_SCHEDULER_PLUGIN_IMAGE=sched_sched\nTAS_SCHEDULER_PLUGIN_CONTROLLER_IMAGE=sched_ctrl\nTAS_RESOURCE_EXPORTER_IMAGE=rte",
 		},
 		{
-			name:         "text/nfd",
-			kind:         FormatText,
-			updaterImage: NodeFeatureDiscoveryImage,
-			expected:     "TAS_SCHEDULER_PLUGIN_IMAGE=sched_sched\nTAS_SCHEDULER_PLUGIN_CONTROLLER_IMAGE=sched_ctrl\nTAS_RESOURCE_EXPORTER_IMAGE=nfd",
+			name:        "text/nfd",
+			kind:        FormatText,
+			updaterType: "NFD",
+			expected:    "TAS_SCHEDULER_PLUGIN_IMAGE=sched_sched\nTAS_SCHEDULER_PLUGIN_CONTROLLER_IMAGE=sched_ctrl\nTAS_RESOURCE_EXPORTER_IMAGE=nfd",
 		},
 		{
-			name:         "json/rte",
-			kind:         FormatJSON,
-			updaterImage: ResourceTopologyExporterImage,
-			expected:     `{"topology_updater":"rte","scheduler_plugin":"sched_sched","scheduler_controller":"sched_ctrl"}`,
+			name:        "json/rte",
+			kind:        FormatJSON,
+			updaterType: "RTE",
+			expected:    `{"topology_updater":"rte","scheduler_plugin":"sched_sched","scheduler_controller":"sched_ctrl"}`,
 		},
 		{
-			name:         "json/nfd",
-			kind:         FormatJSON,
-			updaterImage: NodeFeatureDiscoveryImage,
-			expected:     `{"topology_updater":"nfd","scheduler_plugin":"sched_sched","scheduler_controller":"sched_ctrl"}`,
+			name:        "json/nfd",
+			kind:        FormatJSON,
+			updaterType: "NFD",
+			expected:    `{"topology_updater":"nfd","scheduler_plugin":"sched_sched","scheduler_controller":"sched_ctrl"}`,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			Setup(testGetImage)
+			imgs := GetWithFunc(false, testGetImage)
 
-			imo := NewOutput(tc.updaterImage)
+			imo := NewOutput(imgs, tc.updaterType)
 			var buf bytes.Buffer
 			imo.Format(tc.kind, &buf)
 			got := strings.TrimSpace(buf.String())

--- a/pkg/objectupdate/nfd/nfd.go
+++ b/pkg/objectupdate/nfd/nfd.go
@@ -52,7 +52,8 @@ func UpdaterDaemonSet(ds *appsv1.DaemonSet, opts options.DaemonSet) {
 
 		c.Args = flags.Argv()
 
-		c.Image = images.NodeFeatureDiscoveryImage
+		imgs := images.Get()
+		c.Image = imgs.NodeFeatureDiscovery
 	}
 
 	if opts.NodeSelector != nil {

--- a/pkg/objectupdate/rte/rte.go
+++ b/pkg/objectupdate/rte/rte.go
@@ -73,7 +73,8 @@ func ContainerConfig(podSpec *corev1.PodSpec, cnt *corev1.Container, configMapNa
 func DaemonSet(ds *appsv1.DaemonSet, plat platform.Platform, configMapName string, opts options.DaemonSet) {
 	podSpec := &ds.Spec.Template.Spec
 	if cntSpec := objectupdate.FindContainerByName(ds.Spec.Template.Spec.Containers, manifests.ContainerNameRTE); cntSpec != nil {
-		cntSpec.Image = images.ResourceTopologyExporterImage
+		imgs := images.Get()
+		cntSpec.Image = imgs.ResourceTopologyExporter
 
 		cntSpec.ImagePullPolicy = corev1.PullAlways
 		if opts.PullIfNotPresent {

--- a/pkg/objectupdate/sched/sched.go
+++ b/pkg/objectupdate/sched/sched.go
@@ -28,9 +28,10 @@ import (
 )
 
 func SchedulerDeployment(dp *appsv1.Deployment, pullIfNotPresent, ctrlPlaneAffinity bool, verbose int) {
+	imgs := images.Get()
 	cnt := &dp.Spec.Template.Spec.Containers[0] // shortcut
 
-	cnt.Image = images.SchedulerPluginSchedulerImage
+	cnt.Image = imgs.SchedulerPluginScheduler
 	cnt.ImagePullPolicy = pullPolicy(pullIfNotPresent)
 
 	flags := flagcodec.ParseArgvKeyValue(cnt.Args, flagcodec.WithFlagNormalization)
@@ -43,7 +44,8 @@ func SchedulerDeployment(dp *appsv1.Deployment, pullIfNotPresent, ctrlPlaneAffin
 }
 
 func ControllerDeployment(dp *appsv1.Deployment, pullIfNotPresent, ctrlPlaneAffinity bool) {
-	dp.Spec.Template.Spec.Containers[0].Image = images.SchedulerPluginControllerImage
+	imgs := images.Get()
+	dp.Spec.Template.Spec.Containers[0].Image = imgs.SchedulerPluginController
 	dp.Spec.Template.Spec.Containers[0].ImagePullPolicy = pullPolicy(pullIfNotPresent)
 
 	if ctrlPlaneAffinity {

--- a/test/e2e/local.go
+++ b/test/e2e/local.go
@@ -1,0 +1,143 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ */
+
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-version"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("[PositiveFlow][Local] Deployer version", func() {
+	ginkgo.Context("with the tool available", func() {
+		ginkgo.It("it should show the correct version", func() {
+			cmdline := []string{
+				filepath.Join(binariesPath, "deployer"),
+				"version",
+			}
+			fmt.Fprintf(ginkgo.GinkgoWriter, "running: %v\n", cmdline)
+
+			cmd := exec.Command(cmdline[0], cmdline[1:]...)
+			cmd.Stderr = ginkgo.GinkgoWriter
+
+			out, err := cmd.Output()
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			text := strings.TrimSpace(string(out))
+			fmt.Fprintf(ginkgo.GinkgoWriter, "reported version: %q\n", text)
+			gomega.Expect(text).ToNot(gomega.BeEmpty())
+			_, err = version.NewVersion(text)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		})
+	})
+})
+
+var _ = ginkgo.Describe("[PositiveFlow][Local] Deployer images", func() {
+	ginkgo.Context("with the tool available", func() {
+		ginkgo.It("it should emit the images being used", func() {
+			cmdline := []string{
+				filepath.Join(binariesPath, "deployer"),
+				"images",
+				"--json",
+			}
+			fmt.Fprintf(ginkgo.GinkgoWriter, "running: %v\n", cmdline)
+
+			cmd := exec.Command(cmdline[0], cmdline[1:]...)
+			cmd.Stderr = ginkgo.GinkgoWriter
+
+			out, err := cmd.Output()
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			imo := imageOutput{}
+			if err := json.Unmarshal(out, &imo); err != nil {
+				ginkgo.Fail(fmt.Sprintf("Error unmarshalling output %q: %v", out, err))
+			}
+
+			gomega.Expect(imo.TopologyUpdater).ToNot(gomega.BeNil())
+			gomega.Expect(imo.SchedulerPlugin).ToNot(gomega.BeNil())
+			gomega.Expect(imo.SchedulerController).ToNot(gomega.BeNil())
+		})
+	})
+})
+
+var _ = ginkgo.Describe("[PositiveFlow][Local] Deployer render", func() {
+	ginkgo.Context("with default settings", func() {
+		ginkgo.Context("with focus on topology-updater", func() {
+			ginkgo.DescribeTable("pods fingerprinting support",
+				func(updaterType string, expected bool) {
+					cmdline := []string{
+						filepath.Join(binariesPath, "deployer"),
+						"-P", "kubernetes:v1.26",
+						"--updater-type=" + updaterType,
+						"--updater-pfp-enable=" + strconv.FormatBool(expected),
+						"render",
+					}
+					fmt.Fprintf(ginkgo.GinkgoWriter, "running: %v\n", cmdline)
+
+					cmd := exec.Command(cmdline[0], cmdline[1:]...)
+					cmd.Stderr = ginkgo.GinkgoWriter
+					out, err := cmd.Output()
+					gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+					text := string(out)
+					// TODO: pretty crude. We should do something smarter
+					haveFlag := strings.Contains(text, fmt.Sprintf("--pods-fingerprint=%v", strconv.FormatBool(expected)))
+					desc := fmt.Sprintf("pods fingerprinting setting found=%v", haveFlag)
+					gomega.Expect(haveFlag).To(gomega.BeTrue(), desc)
+				},
+				ginkgo.Entry("RTE pfp on", "RTE", true),
+				ginkgo.Entry("NFD pfp on", "NFD", true),
+				ginkgo.Entry("RTE pfp off", "RTE", false),
+				ginkgo.Entry("NFD pfp off", "NFD", false),
+			)
+		})
+	})
+
+	ginkgo.Context("with cluster image overrides", func() {
+		ginkgo.It("it should reflect the overrides in the output", func() {
+			cmdline := []string{
+				filepath.Join(binariesPath, "deployer"),
+				"-P", "kubernetes:v1.24",
+				"render",
+			}
+			fmt.Fprintf(ginkgo.GinkgoWriter, "running: %v\n", cmdline)
+
+			testSchedPlugImage := "quay.io/sched/sched:test000"
+			testResTopoExImage := "quay.io/rte/rte:test000"
+
+			cmd := exec.Command(cmdline[0], cmdline[1:]...)
+			cmd.Stderr = ginkgo.GinkgoWriter
+			cmd.Env = append(cmd.Env, fmt.Sprintf("TAS_SCHEDULER_PLUGIN_IMAGE=%s", testSchedPlugImage))
+			cmd.Env = append(cmd.Env, fmt.Sprintf("TAS_RESOURCE_EXPORTER_IMAGE=%s", testResTopoExImage))
+
+			out, err := cmd.Output()
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			text := string(out)
+			gomega.Expect(strings.Contains(text, testSchedPlugImage)).To(gomega.BeTrue())
+			gomega.Expect(strings.Contains(text, testResTopoExImage)).To(gomega.BeTrue())
+		})
+	})
+})

--- a/test/e2e/positive.go
+++ b/test/e2e/positive.go
@@ -22,12 +22,9 @@ import (
 	"fmt"
 	"os/exec"
 	"path/filepath"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/hashicorp/go-version"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -49,118 +46,6 @@ import (
 	e2enodes "github.com/k8stopologyawareschedwg/deployer/test/e2e/utils/nodes"
 	e2epods "github.com/k8stopologyawareschedwg/deployer/test/e2e/utils/pods"
 )
-
-var _ = ginkgo.Describe("[PositiveFlow] Deployer version", func() {
-	ginkgo.Context("with the tool available", func() {
-		ginkgo.It("it should show the correct version", func() {
-			cmdline := []string{
-				filepath.Join(binariesPath, "deployer"),
-				"version",
-			}
-			fmt.Fprintf(ginkgo.GinkgoWriter, "running: %v\n", cmdline)
-
-			cmd := exec.Command(cmdline[0], cmdline[1:]...)
-			cmd.Stderr = ginkgo.GinkgoWriter
-
-			out, err := cmd.Output()
-			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-
-			text := strings.TrimSpace(string(out))
-			fmt.Fprintf(ginkgo.GinkgoWriter, "reported version: %q\n", text)
-			gomega.Expect(text).ToNot(gomega.BeEmpty())
-			_, err = version.NewVersion(text)
-			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-		})
-	})
-})
-
-var _ = ginkgo.Describe("[PositiveFlow] Deployer images", func() {
-	ginkgo.Context("with the tool available", func() {
-		ginkgo.It("it should emit the images being used", func() {
-			cmdline := []string{
-				filepath.Join(binariesPath, "deployer"),
-				"images",
-				"--json",
-			}
-			fmt.Fprintf(ginkgo.GinkgoWriter, "running: %v\n", cmdline)
-
-			cmd := exec.Command(cmdline[0], cmdline[1:]...)
-			cmd.Stderr = ginkgo.GinkgoWriter
-
-			out, err := cmd.Output()
-			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-
-			imo := imageOutput{}
-			if err := json.Unmarshal(out, &imo); err != nil {
-				ginkgo.Fail(fmt.Sprintf("Error unmarshalling output %q: %v", out, err))
-			}
-
-			gomega.Expect(imo.TopologyUpdater).ToNot(gomega.BeNil())
-			gomega.Expect(imo.SchedulerPlugin).ToNot(gomega.BeNil())
-			gomega.Expect(imo.SchedulerController).ToNot(gomega.BeNil())
-		})
-	})
-})
-
-var _ = ginkgo.Describe("[PositiveFlow] Deployer render", func() {
-	ginkgo.Context("with default settings", func() {
-		ginkgo.Context("with focus on topology-updater", func() {
-			ginkgo.DescribeTable("pods fingerprinting support",
-				func(updaterType string, expected bool) {
-					cmdline := []string{
-						filepath.Join(binariesPath, "deployer"),
-						"-P", "kubernetes:v1.26",
-						"--updater-type=" + updaterType,
-						"--updater-pfp-enable=" + strconv.FormatBool(expected),
-						"render",
-					}
-					fmt.Fprintf(ginkgo.GinkgoWriter, "running: %v\n", cmdline)
-
-					cmd := exec.Command(cmdline[0], cmdline[1:]...)
-					cmd.Stderr = ginkgo.GinkgoWriter
-					out, err := cmd.Output()
-					gomega.Expect(err).ToNot(gomega.HaveOccurred())
-
-					text := string(out)
-					// TODO: pretty crude. We should do something smarter
-					haveFlag := strings.Contains(text, fmt.Sprintf("--pods-fingerprint=%v", strconv.FormatBool(expected)))
-					desc := fmt.Sprintf("pods fingerprinting setting found=%v", haveFlag)
-					gomega.Expect(haveFlag).To(gomega.BeTrue(), desc)
-				},
-				ginkgo.Entry("RTE pfp on", "RTE", true),
-				ginkgo.Entry("NFD pfp on", "NFD", true),
-				ginkgo.Entry("RTE pfp off", "RTE", false),
-				ginkgo.Entry("NFD pfp off", "NFD", false),
-			)
-		})
-	})
-
-	ginkgo.Context("with cluster image overrides", func() {
-		ginkgo.It("it should reflect the overrides in the output", func() {
-			cmdline := []string{
-				filepath.Join(binariesPath, "deployer"),
-				"-P", "kubernetes:v1.24",
-				"render",
-			}
-			fmt.Fprintf(ginkgo.GinkgoWriter, "running: %v\n", cmdline)
-
-			testSchedPlugImage := "quay.io/sched/sched:test000"
-			testResTopoExImage := "quay.io/rte/rte:test000"
-
-			cmd := exec.Command(cmdline[0], cmdline[1:]...)
-			cmd.Stderr = ginkgo.GinkgoWriter
-			cmd.Env = append(cmd.Env, fmt.Sprintf("TAS_SCHEDULER_PLUGIN_IMAGE=%s", testSchedPlugImage))
-			cmd.Env = append(cmd.Env, fmt.Sprintf("TAS_RESOURCE_EXPORTER_IMAGE=%s", testResTopoExImage))
-
-			out, err := cmd.Output()
-			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-
-			text := string(out)
-			gomega.Expect(strings.Contains(text, testSchedPlugImage)).To(gomega.BeTrue())
-			gomega.Expect(strings.Contains(text, testResTopoExImage)).To(gomega.BeTrue())
-		})
-	})
-})
 
 var _ = ginkgo.Describe("[PositiveFlow] Deployer detection", func() {
 	ginkgo.Context("with cluster with the expected settings", func() {


### PR DESCRIPTION
We had a bug on which the `images` command, little more than a thin wrapper over the `images` package, didn't honor the environment variables override. The root cause is still unknown.

However, the package had a lot of unnecessary implicit baggage, doing stuff at `init` time, using globals.

So we take the chance to do a massive cleanup and remove most of the implicit. The API surface is now smaller and cleaner and the flow is much more straightforward.

This is an API breakage but the users of this package were already few and the updates are pretty simple.