### PR TITLE
rbac: add helper to update role for leaderelection

### DIFF
--- a/pkg/manifests/sched/sched.go
+++ b/pkg/manifests/sched/sched.go
@@ -154,7 +154,7 @@ func (mf Manifests) Render(logger logr.Logger, opts options.Scheduler) (Manifest
 	rbacupdate.RoleBinding(ret.RBController, ret.SAController.Name, ret.Namespace.Name)
 	ret.DPController.Namespace = ret.Namespace.Name
 
-	rbacupdate.Role(ret.RSchedulerElect, ret.Namespace.Name)
+	rbacupdate.RoleForLeaderElection(ret.RSchedulerElect, ret.Namespace.Name, leap.ResourceName)
 
 	ret.SAScheduler.Namespace = ret.Namespace.Name
 	rbacupdate.ClusterRoleBinding(ret.CRBScheduler, ret.SAScheduler.Name, ret.Namespace.Name)
@@ -273,11 +273,8 @@ func leaderElectionParamsFromOpts(opts options.Scheduler) (manifests.LeaderElect
 	var err error
 	tokens := strings.Split(opts.LeaderElectionResource, "/")
 	if len(tokens) == 1 {
-		// special case, see docs of strings.Split
-		if tokens[0] == opts.LeaderElectionResource {
-			err = fmt.Errorf("malformed leader election resource: %q", opts.LeaderElectionResource)
-		} else {
-			leap.ResourceNamespace = tokens[0]
+		if len(tokens[0]) > 0 { // special case, see docs of strings.Split
+			leap.ResourceName = tokens[0]
 		}
 	} else if len(tokens) == 2 {
 		if len(tokens[0]) > 0 {

--- a/pkg/manifests/sched/sched_test.go
+++ b/pkg/manifests/sched/sched_test.go
@@ -17,7 +17,6 @@
 package sched
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -124,7 +123,6 @@ func Test_leaderElectionParamsFromOpts(t *testing.T) {
 				ResourceName:      manifests.LeaderElectionDefaultName,
 				ResourceNamespace: manifests.LeaderElectionDefaultNamespace,
 			},
-			expectedError: fmt.Errorf("malformed leader election resource: \"\""),
 		},
 		{
 			name: "resource non namespaced, missing sep",
@@ -135,10 +133,9 @@ func Test_leaderElectionParamsFromOpts(t *testing.T) {
 			expectedOK: true,
 			expectedParams: manifests.LeaderElectionParams{
 				LeaderElect:       true,
-				ResourceName:      manifests.LeaderElectionDefaultName,
+				ResourceName:      "foobar",
 				ResourceNamespace: manifests.LeaderElectionDefaultNamespace,
 			},
-			expectedError: fmt.Errorf("malformed leader election resource: \"\""),
 		},
 		{
 			name: "empty namespace",

--- a/pkg/objectupdate/rbac/rbac.go
+++ b/pkg/objectupdate/rbac/rbac.go
@@ -20,8 +20,30 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 )
 
-func Role(ro *rbacv1.Role, namespace string) {
+// TODO replace with k8s constants if/when available
+const (
+	apiGroupCore         = ""
+	apiGroupCoordination = "coordination.k8s.io"
+)
+
+// TODO replace with k8s constants if/when available
+const (
+	resourceEndpoints = "endpoints"
+	resourceLeases    = "leases"
+)
+
+func RoleForLeaderElection(ro *rbacv1.Role, namespace, resourceName string) {
 	ro.Namespace = namespace
+
+	for idx := 0; idx < len(ro.Rules); idx++ {
+		ru := &ro.Rules[idx] // shortcut
+		if ru.APIGroups[0] == apiGroupCore && ru.Resources[0] == resourceEndpoints {
+			ru.ResourceNames = []string{resourceName}
+		}
+		if ru.APIGroups[0] == apiGroupCoordination && ru.Resources[0] == resourceLeases {
+			ru.ResourceNames = []string{resourceName}
+		}
+	}
 }
 
 func RoleBinding(rb *rbacv1.RoleBinding, serviceAccount, namespace string) {

--- a/pkg/objectupdate/rbac/rbac_test.go
+++ b/pkg/objectupdate/rbac/rbac_test.go
@@ -18,10 +18,13 @@ package rbac
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/k8stopologyawareschedwg/deployer/pkg/manifests"
 )
 
 func TestRoleBinding(t *testing.T) {
@@ -189,6 +192,172 @@ func TestClusterRoleBinding(t *testing.T) {
 			ClusterRoleBinding(got, tc.servAcc, tc.namespace)
 			if !reflect.DeepEqual(got, tc.expected) {
 				t.Errorf("\ngot=%#v\nexp=%#v\n", got, tc.expected)
+			}
+		})
+	}
+}
+
+const testRBACBase = `apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: topology-aware-scheduler-leader-elect
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - ""
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - ""
+  resources:
+  - leases
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
+  resourceNames:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resourceNames:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - get
+  - update`
+
+func TestRoleForLeaderElection(t *testing.T) {
+	testCases := []struct {
+		desc         string
+		namespace    string
+		resName      string
+		rbac         string
+		expectedRBAC string
+	}{
+		{
+			desc:         "empty",
+			rbac:         testRBACBase,
+			expectedRBAC: testRBACBase,
+		},
+		{
+			desc:      "fix-namespace",
+			namespace: "test-foobar",
+			rbac:      testRBACBase,
+			expectedRBAC: `apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: topology-aware-scheduler-leader-elect
+  namespace: test-foobar
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - ""
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - ""
+  resources:
+  - leases
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
+  resourceNames:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resourceNames:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - get
+  - update`,
+		},
+		{
+			desc:    "fix-resource-name",
+			resName: "test-tas-sched",
+			rbac:    testRBACBase,
+			expectedRBAC: `apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: topology-aware-scheduler-leader-elect
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - test-tas-sched
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - test-tas-sched
+  resources:
+  - leases
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
+  resourceNames:
+  - test-tas-sched
+  resources:
+  - endpoints
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resourceNames:
+  - test-tas-sched
+  resources:
+  - endpoints
+  verbs:
+  - get
+  - update`,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			obj, err := manifests.DeserializeObjectFromData([]byte(tc.rbac))
+			if err != nil {
+				t.Fatalf("deserialize error: %v", err)
+			}
+			ro, ok := obj.(*rbacv1.Role)
+			if !ok {
+				t.Fatalf("decoded unsupported object: %v %T", obj, obj)
+			}
+			RoleForLeaderElection(ro, tc.namespace, tc.resName)
+			data, err := manifests.SerializeObjectToData(ro)
+			if err != nil {
+				t.Fatalf("serialize error: %v", err)
+			}
+			got := strings.TrimSpace(string(data))
+			if got != tc.expectedRBAC {
+				t.Errorf("got=%v\nexpected=%v\n", got, tc.expectedRBAC)
 			}
 		})
 	}


### PR DESCRIPTION
We want to minimize privilege for the leader election role, this requires setting the specific resource name in the role definition, to let the scheduler change only its own resource.

Add helper, with tests, to enable this.