### PR TITLE
add utilities and options to detect control plane

### DIFF
--- a/cmd/deployer/main.go
+++ b/cmd/deployer/main.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/klog/v2/klogr"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/k8stopologyawareschedwg/deployer/pkg/clientutil"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/commands"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/options"
@@ -65,14 +64,7 @@ func NewVersionCommand(env *deployer.Environment, commonOpts *options.Options) *
 func main() {
 	ctrllog.SetLogger(klogr.NewWithOptions(klogr.WithFormat(klogr.FormatKlog)))
 
-	cli, err := clientutil.New()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(1)
-	}
-
 	env := deployer.Environment{
-		Cli: cli,
 		Ctx: context.Background(),
 		Log: stdr.New(log.New(os.Stderr, "", log.LstdFlags)),
 	}

--- a/pkg/clientutil/nodes/nodes.go
+++ b/pkg/clientutil/nodes/nodes.go
@@ -28,14 +28,18 @@ import (
 )
 
 const (
-	// RoleWorker contains the worker role
-	RoleWorker = "worker"
+	RoleControlPlane = "control-plane"
+	RoleWorker       = "worker"
 )
 
 const (
 	// LabelRole contains the key for the role label
 	LabelRole = "node-role.kubernetes.io"
 )
+
+func GetControlPlane(env *deployer.Environment) ([]corev1.Node, error) {
+	return GetByRole(env, RoleControlPlane)
+}
 
 func GetWorkers(env *deployer.Environment) ([]corev1.Node, error) {
 	return GetByRole(env, RoleWorker)

--- a/pkg/commands/deploy.go
+++ b/pkg/commands/deploy.go
@@ -67,7 +67,7 @@ func NewDeployAPICommand(env *deployer.Environment, commonOpts *options.Options)
 				return fmt.Errorf("cannot autodetect the platform version, and no version given")
 			}
 
-			env.Log.Info("detection", "platform", commonOpts.ClusterPlatform, "reason", reason, "version", commonOpts.ClusterVersion, "source", source)
+			env.Log.V(3).Info("detection", "platform", commonOpts.ClusterPlatform, "reason", reason, "version", commonOpts.ClusterVersion, "source", source)
 			if err := api.Deploy(env, options.API{Platform: commonOpts.ClusterPlatform}); err != nil {
 				return err
 			}
@@ -100,7 +100,7 @@ func NewDeploySchedulerPluginCommand(env *deployer.Environment, commonOpts *opti
 				return fmt.Errorf("cannot autodetect the platform version, and no version given")
 			}
 
-			env.Log.Info("detection", "platform", commonOpts.ClusterPlatform, "reason", reason, "version", commonOpts.ClusterVersion, "source", source)
+			env.Log.V(3).Info("detection", "platform", commonOpts.ClusterPlatform, "reason", reason, "version", commonOpts.ClusterVersion, "source", source)
 			return sched.Deploy(env, options.Scheduler{
 				Platform:               commonOpts.ClusterPlatform,
 				WaitCompletion:         commonOpts.WaitCompletion,
@@ -143,7 +143,7 @@ func NewDeployTopologyUpdaterCommand(env *deployer.Environment, commonOpts *opti
 				return fmt.Errorf("cannot autodetect the platform version, and no version given")
 			}
 
-			env.Log.Info("detection", "platform", commonOpts.ClusterPlatform, "reason", reason, "version", commonOpts.ClusterVersion, "source", source)
+			env.Log.V(3).Info("detection", "platform", commonOpts.ClusterPlatform, "reason", reason, "version", commonOpts.ClusterVersion, "source", source)
 			return updaters.Deploy(env, commonOpts.UpdaterType, options.Updater{
 				Platform:        commonOpts.ClusterPlatform,
 				PlatformVersion: commonOpts.ClusterVersion,

--- a/pkg/commands/detect.go
+++ b/pkg/commands/detect.go
@@ -45,7 +45,7 @@ func NewDetectCommand(env *deployer.Environment, commonOpts *options.Options) *c
 			platKind, kindReason, _ := detect.FindPlatform(env.Ctx, commonOpts.UserPlatform)
 			platVer, verReason, _ := detect.FindVersion(env.Ctx, platKind.Discovered, commonOpts.UserPlatformVersion)
 
-			env.Log.Info("detection", "platform", platKind, "reason", kindReason, "version", platVer, "source", verReason)
+			env.Log.V(3).Info("detection", "platform", platKind, "reason", kindReason, "version", platVer, "source", verReason)
 
 			cluster := detect.ClusterInfo{
 				Platform: platKind,

--- a/pkg/commands/remove.go
+++ b/pkg/commands/remove.go
@@ -51,7 +51,7 @@ func NewRemoveCommand(env *deployer.Environment, commonOpts *options.Options) *c
 			if commonOpts.ClusterVersion == platform.MissingVersion {
 				return fmt.Errorf("cannot autodetect the platform version, and no version given")
 			}
-			env.Log.Info("detection", "platform", commonOpts.ClusterPlatform, "reason", reason, "version", commonOpts.ClusterVersion, "source", source)
+			env.Log.V(3).Info("detection", "platform", commonOpts.ClusterPlatform, "reason", reason, "version", commonOpts.ClusterVersion, "source", source)
 
 			err = sched.Remove(env, options.Scheduler{
 				Platform:               commonOpts.ClusterPlatform,
@@ -123,7 +123,7 @@ func NewRemoveAPICommand(env *deployer.Environment, commonOpts *options.Options)
 				return fmt.Errorf("cannot autodetect the platform version, and no version given")
 			}
 
-			env.Log.Info("detection", "platform", commonOpts.ClusterPlatform, "reason", reason, "version", commonOpts.ClusterVersion, "source", source)
+			env.Log.V(3).Info("detection", "platform", commonOpts.ClusterPlatform, "reason", reason, "version", commonOpts.ClusterVersion, "source", source)
 			if err := api.Remove(env, options.API{Platform: commonOpts.ClusterPlatform}); err != nil {
 				return err
 			}
@@ -156,7 +156,7 @@ func NewRemoveSchedulerPluginCommand(env *deployer.Environment, commonOpts *opti
 				return fmt.Errorf("cannot autodetect the platform version, and no version given")
 			}
 
-			env.Log.Info("detection", "platform", commonOpts.ClusterPlatform, "reason", reason, "version", commonOpts.ClusterVersion, "source", source)
+			env.Log.V(3).Info("detection", "platform", commonOpts.ClusterPlatform, "reason", reason, "version", commonOpts.ClusterVersion, "source", source)
 			return sched.Remove(env, options.Scheduler{
 				Platform:               commonOpts.ClusterPlatform,
 				WaitCompletion:         commonOpts.WaitCompletion,
@@ -199,7 +199,7 @@ func NewRemoveTopologyUpdaterCommand(env *deployer.Environment, commonOpts *opti
 				return fmt.Errorf("cannot autodetect the platform version, and no version given")
 			}
 
-			env.Log.Info("detection", "platform", commonOpts.ClusterPlatform, "reason", reason, "version", commonOpts.ClusterVersion, "source", source)
+			env.Log.V(3).Info("detection", "platform", commonOpts.ClusterPlatform, "reason", reason, "version", commonOpts.ClusterVersion, "source", source)
 			return updaters.Remove(env, commonOpts.UpdaterType, options.Updater{
 				Platform:        commonOpts.ClusterPlatform,
 				PlatformVersion: commonOpts.ClusterVersion,

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -120,6 +120,11 @@ func PostSetupOptions(env *deployer.Environment, commonOpts *options.Options, in
 	wait.SetBaseValues(commonOpts.WaitInterval, commonOpts.WaitTimeout)
 
 	if internalOpts.replicas < 0 {
+		err := env.EnsureClient()
+		if err != nil {
+			return err
+		}
+
 		env.Log.V(4).Info("autodetecting replicas from control plane")
 		info, err := detect.ControlPlaneFromLister(env.Ctx, env.Cli)
 		if err != nil {

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -38,6 +38,7 @@ import (
 )
 
 type internalOptions struct {
+	verbose                     int
 	rteConfigFile               string
 	schedScoringStratConfigFile string
 	schedCacheParamsConfigFile  string
@@ -93,6 +94,7 @@ func NewRootCommand(extraCmds ...NewCommandFunc) *cobra.Command {
 }
 
 func InitFlags(flags *pflag.FlagSet, commonOpts *options.Options, internalOpts *internalOptions) {
+	flags.IntVarP(&internalOpts.verbose, "verbose", "v", 1, "set the tool verbosity.")
 	flags.StringVarP(&internalOpts.plat, "platform", "P", "", "platform kind:version to deploy on (example kubernetes:v1.22)")
 	flags.StringVar(&internalOpts.rteConfigFile, "rte-config-file", "", "inject rte configuration reading from this file.")
 	flags.StringVar(&internalOpts.schedScoringStratConfigFile, "sched-scoring-strat-config-file", "", "inject scheduler scoring strategy configuration reading from this file.")
@@ -116,6 +118,8 @@ func InitFlags(flags *pflag.FlagSet, commonOpts *options.Options, internalOpts *
 }
 
 func PostSetupOptions(env *deployer.Environment, commonOpts *options.Options, internalOpts *internalOptions) error {
+	stdr.SetVerbosity(internalOpts.verbose) // MUST be the very first thing
+
 	env.Log.V(3).Info("global polling interval=%v timeout=%v", commonOpts.WaitInterval, commonOpts.WaitTimeout)
 	wait.SetBaseValues(commonOpts.WaitInterval, commonOpts.WaitTimeout)
 

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -53,11 +53,7 @@ func ShowHelp(cmd *cobra.Command, args []string) error {
 type NewCommandFunc func(ev *deployer.Environment, ko *options.Options) *cobra.Command
 
 // NewRootCommand returns entrypoint command to interact with all other commands
-func NewRootCommand(extraCmds ...NewCommandFunc) *cobra.Command {
-	env := deployer.Environment{
-		Ctx: context.Background(),
-		Log: stdr.New(log.New(os.Stderr, "", log.LstdFlags)),
-	}
+func NewRootCommand(env *deployer.Environment, extraCmds ...NewCommandFunc) *cobra.Command {
 	internalOpts := internalOptions{}
 	commonOpts := options.Options{}
 
@@ -66,7 +62,7 @@ func NewRootCommand(extraCmds ...NewCommandFunc) *cobra.Command {
 		Short: "deployer helps setting up all the topology-aware-scheduling components on a kubernetes cluster",
 
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return PostSetupOptions(&env, &commonOpts, &internalOpts)
+			return PostSetupOptions(env, &commonOpts, &internalOpts)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return ShowHelp(cmd, args)
@@ -78,16 +74,16 @@ func NewRootCommand(extraCmds ...NewCommandFunc) *cobra.Command {
 	InitFlags(root.PersistentFlags(), &commonOpts, &internalOpts)
 
 	root.AddCommand(
-		NewRenderCommand(&env, &commonOpts),
-		NewValidateCommand(&env, &commonOpts),
-		NewDeployCommand(&env, &commonOpts),
-		NewRemoveCommand(&env, &commonOpts),
-		NewSetupCommand(&env, &commonOpts),
-		NewDetectCommand(&env, &commonOpts),
-		NewImagesCommand(&env, &commonOpts),
+		NewRenderCommand(env, &commonOpts),
+		NewValidateCommand(env, &commonOpts),
+		NewDeployCommand(env, &commonOpts),
+		NewRemoveCommand(env, &commonOpts),
+		NewSetupCommand(env, &commonOpts),
+		NewDetectCommand(env, &commonOpts),
+		NewImagesCommand(env, &commonOpts),
 	)
 	for _, extraCmd := range extraCmds {
-		root.AddCommand(extraCmd(&env, &commonOpts))
+		root.AddCommand(extraCmd(env, &commonOpts))
 	}
 
 	return root

--- a/pkg/deploy/cluster.go
+++ b/pkg/deploy/cluster.go
@@ -44,7 +44,7 @@ func OnCluster(env *deployer.Environment, commonOpts *options.Options) error {
 		return fmt.Errorf("cannot autodetect the platform version, and no version given")
 	}
 
-	env.Log.Info("detection", "platform", commonOpts.ClusterPlatform, "reason", reason, "version", commonOpts.ClusterVersion, "source", source)
+	env.Log.V(3).Info("detection", "platform", commonOpts.ClusterPlatform, "reason", reason, "version", commonOpts.ClusterVersion, "source", source)
 	if err := api.Deploy(env, options.API{
 		Platform: commonOpts.ClusterPlatform,
 	}); err != nil {

--- a/pkg/deployer/platform/detect/autoselection.go
+++ b/pkg/deployer/platform/detect/autoselection.go
@@ -41,6 +41,22 @@ type ClusterInfo struct {
 	Version  VersionInfo  `json:"version"`
 }
 
+type ControlPlaneInfo struct {
+	NodeCount int `json:"nodeCount"`
+}
+
+func (cpi ControlPlaneInfo) String() string {
+	return fmt.Sprintf("nodes=%d", cpi.NodeCount)
+}
+
+func (cpi ControlPlaneInfo) ToJSON() string {
+	data, err := json.Marshal(cpi)
+	if err != nil {
+		return `{"error":` + fmt.Sprintf("%q", err) + `}`
+	}
+	return string(data)
+}
+
 func (ci ClusterInfo) String() string {
 	return fmt.Sprintf("%s:%s", ci.Platform.Discovered, ci.Version.Discovered)
 }


### PR DESCRIPTION
add utilities to getch all the controlplane nodes, similarly to worker node which we support since forever.
We can use this code to autodetermine the replica size.