### PR TITLE
OCP: SELinux: make custom policy opt-in and off by default

### DIFF
--- a/pkg/assets/selinux/consts.go
+++ b/pkg/assets/selinux/consts.go
@@ -18,7 +18,8 @@ package selinux
 
 const (
 	RTEPolicyFileName           = "/etc/selinux/rte.cil"
-	RTEContextType              = "rte.process"
+	RTEContextType              = "container_device_plugin_t"
+	RTEContextTypeLegacy        = "rte.process"
 	RTEContextLevel             = "s0"
 	RTEPolicyInstallServiceName = "rte-selinux-policy-install.service"
 )

--- a/pkg/commands/render.go
+++ b/pkg/commands/render.go
@@ -141,11 +141,12 @@ func makeUpdaterObjects(commonOpts *options.Options) ([]client.Object, string, e
 	}
 
 	opts := options.Updater{
-		PlatformVersion: commonOpts.UserPlatformVersion,
-		Platform:        commonOpts.UserPlatform,
-		RTEConfigData:   commonOpts.RTEConfigData,
-		DaemonSet:       options.ForDaemonSet(commonOpts),
-		EnableCRIHooks:  commonOpts.UpdaterCRIHooksEnable,
+		PlatformVersion:     commonOpts.UserPlatformVersion,
+		Platform:            commonOpts.UserPlatform,
+		RTEConfigData:       commonOpts.RTEConfigData,
+		DaemonSet:           options.ForDaemonSet(commonOpts),
+		EnableCRIHooks:      commonOpts.UpdaterCRIHooksEnable,
+		CustomSELinuxPolicy: commonOpts.UpdaterCustomSELinuxPolicy,
 	}
 	objs, err := updaters.GetObjects(opts, commonOpts.UpdaterType, namespace)
 	if err != nil {

--- a/pkg/deployer/updaters/objects.go
+++ b/pkg/deployer/updaters/objects.go
@@ -32,7 +32,7 @@ import (
 
 func GetObjects(opts options.Updater, updaterType, namespace string) ([]client.Object, error) {
 	if updaterType == RTE {
-		mf, err := rtemanifests.GetManifests(opts.Platform, opts.PlatformVersion, namespace, opts.EnableCRIHooks)
+		mf, err := rtemanifests.GetManifests(opts.Platform, opts.PlatformVersion, namespace, opts.EnableCRIHooks, opts.CustomSELinuxPolicy)
 		if err != nil {
 			return nil, err
 		}
@@ -58,7 +58,7 @@ func GetObjects(opts options.Updater, updaterType, namespace string) ([]client.O
 
 func getCreatableObjects(env *deployer.Environment, opts options.Updater, updaterType, namespace string) ([]objectwait.WaitableObject, error) {
 	if updaterType == RTE {
-		mf, err := rtemanifests.GetManifests(opts.Platform, opts.PlatformVersion, namespace, opts.EnableCRIHooks)
+		mf, err := rtemanifests.GetManifests(opts.Platform, opts.PlatformVersion, namespace, opts.EnableCRIHooks, opts.CustomSELinuxPolicy)
 		if err != nil {
 			return nil, err
 		}
@@ -84,7 +84,7 @@ func getCreatableObjects(env *deployer.Environment, opts options.Updater, update
 
 func getDeletableObjects(env *deployer.Environment, opts options.Updater, updaterType, namespace string) ([]objectwait.WaitableObject, error) {
 	if updaterType == RTE {
-		mf, err := rtemanifests.GetManifests(opts.Platform, opts.PlatformVersion, namespace, opts.EnableCRIHooks)
+		mf, err := rtemanifests.GetManifests(opts.Platform, opts.PlatformVersion, namespace, opts.EnableCRIHooks, opts.CustomSELinuxPolicy)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -436,7 +436,7 @@ func getTemplateContent(templateContent []byte, templateArgs map[string]string) 
 	return fileContent.Bytes(), nil
 }
 
-func SecurityContextConstraint(component string) (*securityv1.SecurityContextConstraints, error) {
+func SecurityContextConstraint(component string, withCustomSELinuxPolicy bool) (*securityv1.SecurityContextConstraints, error) {
 	if component != ComponentResourceTopologyExporter {
 		return nil, fmt.Errorf("component %q is not an %q component", component, ComponentResourceTopologyExporter)
 	}
@@ -457,6 +457,9 @@ func SecurityContextConstraint(component string) (*securityv1.SecurityContextCon
 			Type:  selinuxassets.RTEContextType,
 			Level: selinuxassets.RTEContextLevel,
 		},
+	}
+	if withCustomSELinuxPolicy {
+		scc.SELinuxContext.SELinuxOptions.Type = selinuxassets.RTEContextTypeLegacy
 	}
 
 	return scc, nil

--- a/pkg/manifests/rte/rte.go
+++ b/pkg/manifests/rte/rte.go
@@ -68,7 +68,10 @@ func (mf Manifests) Clone() Manifests {
 	}
 
 	if mf.plat == platform.OpenShift {
-		ret.MachineConfig = mf.MachineConfig.DeepCopy()
+		//  MachineConfig is obsolete starting from OCP v4.18
+		if mf.MachineConfig != nil {
+			ret.MachineConfig = mf.MachineConfig.DeepCopy()
+		}
 		ret.SecurityContextConstraint = mf.SecurityContextConstraint.DeepCopy()
 	}
 
@@ -110,11 +113,13 @@ func (mf Manifests) Render(opts options.UpdaterDaemon) (Manifests, error) {
 	if mf.plat == platform.OpenShift {
 		rteupdate.SecurityContext(ret.DaemonSet)
 
-		if opts.Name != "" {
-			ret.MachineConfig.Name = ocpupdate.MakeMachineConfigName(opts.Name)
-		}
-		if opts.MachineConfigPoolSelector != nil {
-			ret.MachineConfig.Labels = opts.MachineConfigPoolSelector.MatchLabels
+		if mf.MachineConfig != nil {
+			if opts.Name != "" {
+				ret.MachineConfig.Name = ocpupdate.MakeMachineConfigName(opts.Name)
+			}
+			if opts.MachineConfigPoolSelector != nil {
+				ret.MachineConfig.Labels = opts.MachineConfigPoolSelector.MatchLabels
+			}
 		}
 		ocpupdate.SecurityContextConstraint(ret.SecurityContextConstraint, ret.ServiceAccount)
 	}
@@ -173,14 +178,16 @@ func New(plat platform.Platform) Manifests {
 	return mf
 }
 
-func GetManifests(plat platform.Platform, version platform.Version, namespace string, withCRIHooks bool) (Manifests, error) {
+func GetManifests(plat platform.Platform, version platform.Version, namespace string, withCRIHooks, withCustomSELinuxPolicy bool) (Manifests, error) {
 	var err error
 	mf := New(plat)
 
 	if plat == platform.OpenShift {
-		mf.MachineConfig, err = manifests.MachineConfig(manifests.ComponentResourceTopologyExporter, version, withCRIHooks)
-		if err != nil {
-			return mf, err
+		if withCustomSELinuxPolicy {
+			mf.MachineConfig, err = manifests.MachineConfig(manifests.ComponentResourceTopologyExporter, version, withCRIHooks)
+			if err != nil {
+				return mf, err
+			}
 		}
 
 		mf.SecurityContextConstraint, err = manifests.SecurityContextConstraint(manifests.ComponentResourceTopologyExporter)

--- a/pkg/manifests/rte/rte.go
+++ b/pkg/manifests/rte/rte.go
@@ -17,6 +17,7 @@
 package rte
 
 import (
+	selinuxassets "github.com/k8stopologyawareschedwg/deployer/pkg/assets/selinux"
 	securityv1 "github.com/openshift/api/security/v1"
 	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -111,8 +112,7 @@ func (mf Manifests) Render(opts options.UpdaterDaemon) (Manifests, error) {
 	rteupdate.DaemonSet(ret.DaemonSet, mf.plat, rteConfigMapName, opts.DaemonSet)
 
 	if mf.plat == platform.OpenShift {
-		rteupdate.SecurityContext(ret.DaemonSet)
-
+		selinuxType := selinuxassets.RTEContextType
 		if mf.MachineConfig != nil {
 			if opts.Name != "" {
 				ret.MachineConfig.Name = ocpupdate.MakeMachineConfigName(opts.Name)
@@ -120,7 +120,10 @@ func (mf Manifests) Render(opts options.UpdaterDaemon) (Manifests, error) {
 			if opts.MachineConfigPoolSelector != nil {
 				ret.MachineConfig.Labels = opts.MachineConfigPoolSelector.MatchLabels
 			}
+			// the MachineConfig installs this custom policy which is obsolete starting from OCP v4.18
+			selinuxType = selinuxassets.RTEContextTypeLegacy
 		}
+		rteupdate.SecurityContext(ret.DaemonSet, selinuxType)
 		ocpupdate.SecurityContextConstraint(ret.SecurityContextConstraint, ret.ServiceAccount)
 	}
 
@@ -190,7 +193,7 @@ func GetManifests(plat platform.Platform, version platform.Version, namespace st
 			}
 		}
 
-		mf.SecurityContextConstraint, err = manifests.SecurityContextConstraint(manifests.ComponentResourceTopologyExporter)
+		mf.SecurityContextConstraint, err = manifests.SecurityContextConstraint(manifests.ComponentResourceTopologyExporter, withCustomSELinuxPolicy)
 		if err != nil {
 			return mf, err
 		}

--- a/pkg/objectupdate/rte/rte.go
+++ b/pkg/objectupdate/rte/rte.go
@@ -174,7 +174,7 @@ func MetricsPort(ds *appsv1.DaemonSet, pNum int) {
 	cntSpec.Ports = cp
 }
 
-func SecurityContext(ds *appsv1.DaemonSet) {
+func SecurityContext(ds *appsv1.DaemonSet, selinuxContextType string) {
 	cntSpec := objectupdate.FindContainerByName(ds.Spec.Template.Spec.Containers, manifests.ContainerNameRTE)
 	if cntSpec == nil {
 		return
@@ -186,7 +186,7 @@ func SecurityContext(ds *appsv1.DaemonSet) {
 		cntSpec.SecurityContext = &corev1.SecurityContext{}
 	}
 	cntSpec.SecurityContext.SELinuxOptions = &corev1.SELinuxOptions{
-		Type:  selinuxassets.RTEContextType,
+		Type:  selinuxContextType,
 		Level: selinuxassets.RTEContextLevel,
 	}
 }

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -34,6 +34,7 @@ type Options struct {
 	UpdaterPFPEnable            bool
 	UpdaterNotifEnable          bool
 	UpdaterCRIHooksEnable       bool
+	UpdaterCustomSELinuxPolicy  bool
 	UpdaterSyncPeriod           time.Duration
 	UpdaterVerbose              int
 	SchedProfileName            string
@@ -88,12 +89,13 @@ type UpdaterDaemon struct {
 }
 
 type Updater struct {
-	Platform        platform.Platform
-	PlatformVersion platform.Version
-	WaitCompletion  bool
-	RTEConfigData   string
-	DaemonSet       DaemonSet
-	EnableCRIHooks  bool
+	Platform            platform.Platform
+	PlatformVersion     platform.Version
+	WaitCompletion      bool
+	RTEConfigData       string
+	DaemonSet           DaemonSet
+	EnableCRIHooks      bool
+	CustomSELinuxPolicy bool
 }
 
 func ForDaemonSet(commonOpts *Options) DaemonSet {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -357,7 +357,7 @@ func dumpResourceTopologyExporterPods(ctx context.Context, cli client.Client) {
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 	// TODO: autodetect the platform
-	mfs, err := rte.GetManifests(platform.Kubernetes, platform.Version("1.23"), ns.Name, true)
+	mfs, err := rte.GetManifests(platform.Kubernetes, platform.Version("1.23"), ns.Name, true, true)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	mfs, err = mfs.Render(options.UpdaterDaemon{
 		Namespace: ns.Name,

--- a/test/e2e/manifests.go
+++ b/test/e2e/manifests.go
@@ -60,7 +60,7 @@ var _ = ginkgo.Describe("[ManifestFlow] Deployer rendering", ginkgo.Label("manif
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 				enableCRIHooks := true
-				mf, err := rte.GetManifests(platform.Kubernetes, platform.Version("1.23"), ns.Name, enableCRIHooks)
+				mf, err := rte.GetManifests(platform.Kubernetes, platform.Version("1.23"), ns.Name, enableCRIHooks, true)
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 				mf, err = mf.Render(options.UpdaterDaemon{
 					Namespace: ns.Name,

--- a/test/e2e/negative.go
+++ b/test/e2e/negative.go
@@ -98,7 +98,7 @@ var _ = ginkgo.Describe("[NegativeFlow] Deployer execution with PFP disabled", g
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 				enableCRIHooks := true
-				mf, err := rte.GetManifests(platform.Kubernetes, platform.Version("1.23"), ns.Name, enableCRIHooks)
+				mf, err := rte.GetManifests(platform.Kubernetes, platform.Version("1.23"), ns.Name, enableCRIHooks, true)
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 				mf, err = mf.Render(options.UpdaterDaemon{
 					Namespace: ns.Name,

--- a/test/e2e/positive.go
+++ b/test/e2e/positive.go
@@ -244,7 +244,7 @@ var _ = ginkgo.Describe("[PositiveFlow] Deployer execution", ginkgo.Label("posit
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 				enableCRIHooks := true
-				mf, err := rte.GetManifests(platform.Kubernetes, platform.Version("1.23"), ns.Name, enableCRIHooks)
+				mf, err := rte.GetManifests(platform.Kubernetes, platform.Version("1.23"), ns.Name, enableCRIHooks, true)
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 				mf, err = mf.Render(options.UpdaterDaemon{
 					Namespace: ns.Name,


### PR DESCRIPTION
So far, we were using a custom SELinux policy to allow RTE access to PodResourceAPI socket.

The `container_device_plugin_t` label type is a built-in context, which allows communication with
`kubelet_t` context: https://github.com/containers/container-selinux/pull/178.

The PodResourceAPI socket is an object created by Kubelet so it inherents
the same process context, i.e. `kubelet_t`.

This PR is changing RTE container to use `container_device_plugin_t` and make the logic needed for creating the custom policy as optional and off by default.