### PR TITLE
deployer:flags: `UpdaterCustomSELinuxPolicy`

### DIFF
--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -104,6 +104,7 @@ func InitFlags(flags *pflag.FlagSet, commonOpts *options.Options, internalOpts *
 	flags.BoolVar(&commonOpts.UpdaterPFPEnable, "updater-pfp-enable", true, "toggle PFP support on the updater side.")
 	flags.BoolVar(&commonOpts.UpdaterNotifEnable, "updater-notif-enable", true, "toggle event-based notification support on the updater side.")
 	flags.BoolVar(&commonOpts.UpdaterCRIHooksEnable, "updater-cri-hooks-enable", true, "toggle installation of CRI hooks on the updater side.")
+	flags.BoolVar(&commonOpts.UpdaterCustomSELinuxPolicy, "updater-custom-selinux-policy", false, "toggle installation of selinux policy on the updater side. off by default")
 	flags.DurationVar(&commonOpts.UpdaterSyncPeriod, "updater-sync-period", manifests.DefaultUpdaterSyncPeriod, "tune the updater synchronization (nrt update) interval. Use 0 to disable.")
 	flags.IntVar(&commonOpts.UpdaterVerbose, "updater-verbose", manifests.DefaultUpdaterVerbose, "set the updater verbosiness.")
 	flags.StringVar(&commonOpts.SchedProfileName, "sched-profile-name", schedmanifests.DefaultProfileName, "inject scheduler profile name.")

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -18,12 +18,12 @@ package manifests
 
 import (
 	"encoding/json"
-	selinuxassets "github.com/k8stopologyawareschedwg/deployer/pkg/assets/selinux"
 	"testing"
 
 	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
 	"k8s.io/klog/v2"
 
+	selinuxassets "github.com/k8stopologyawareschedwg/deployer/pkg/assets/selinux"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
 )
 


### PR DESCRIPTION
Add the `UpdaterCustomSELinuxPolicy` flag so we could control
whether we want to install custom policy from the deployer directly.

This flag is off by default.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>