### PR TITLE
detect: add capability to detect HyperShift platform

### DIFF
--- a/pkg/deployer/platform/platform.go
+++ b/pkg/deployer/platform/platform.go
@@ -24,6 +24,7 @@ const (
 	Unknown    = Platform("Unknown")
 	Kubernetes = Platform("Kubernetes")
 	OpenShift  = Platform("OpenShift")
+	HyperShift = Platform("HyperShift")
 )
 
 func (p Platform) String() string {
@@ -37,6 +38,8 @@ func ParsePlatform(plat string) (Platform, bool) {
 		return Kubernetes, true
 	case "openshift":
 		return OpenShift, true
+	case "hypershift":
+		return HyperShift, true
 	default:
 		return Unknown, false
 	}

--- a/pkg/deployer/platform/platform_test.go
+++ b/pkg/deployer/platform/platform_test.go
@@ -37,6 +37,11 @@ func TestRoudnTrip(t *testing.T) {
 			expectedOK: true,
 		},
 		{
+			name:       "HyperShift",
+			expected:   HyperShift,
+			expectedOK: true,
+		},
+		{
 			name:       "foobar",
 			expected:   Unknown,
 			expectedOK: false,


### PR DESCRIPTION
Added the capeability for the deployer to detect
whether the targeted OpenShift platform is of HyperShift flavor.

In future PR on NROP, we'll consume this change to allow the operator performs specific decision given the current platform.