### PR TITLE
[release 0.20][manual] scheduler: set namespace for rolebinding

### DIFF
--- a/pkg/manifests/sched/sched.go
+++ b/pkg/manifests/sched/sched.go
@@ -158,6 +158,7 @@ func (mf Manifests) Render(logger logr.Logger, opts options.Scheduler) (Manifest
 
 	ret.SAScheduler.Namespace = ret.Namespace.Name
 	rbacupdate.ClusterRoleBinding(ret.CRBScheduler, ret.SAScheduler.Name, ret.Namespace.Name)
+	ret.RBSchedulerElect.Namespace = ret.Namespace.Name
 	rbacupdate.RoleBinding(ret.RBSchedulerElect, ret.SAScheduler.Name, ret.Namespace.Name)
 	rbacupdate.RoleBinding(ret.RBSchedulerAuth, ret.SAScheduler.Name, ret.Namespace.Name)
 	ret.DPScheduler.Namespace = ret.Namespace.Name


### PR DESCRIPTION
The topology-aware-scheduler-leader-elect `rolebinding` object is refer to topology-aware-scheduler-leader-elect `role` which is under a specific namespace given the configuration provided to the deploy command.

we should set the right namespace for the `rolebinding` to be the same as the `role` namespace.