### PR TITLE
selinux: allow access to kubelet_var_lib_t

### DIFF
--- a/pkg/assets/selinux/assets.go
+++ b/pkg/assets/selinux/assets.go
@@ -16,6 +16,9 @@ const (
 	ocpVersion413 = "v4.13"
 	ocpVersion414 = "v4.14"
 	ocpVersion415 = "v4.15"
+	ocpVersion416 = "v4.16"
+	ocpVersion417 = "v4.17"
+	ocpVersion418 = "v4.18"
 )
 
 //go:embed selinuxinstall.service.template
@@ -43,6 +46,9 @@ func GetPolicy(ver platform.Version) ([]byte, error) {
 
 func knownVersions() []string {
 	return []string{
+		ocpVersion418,
+		ocpVersion417,
+		ocpVersion416,
 		ocpVersion415,
 		ocpVersion414,
 		ocpVersion413,

--- a/pkg/assets/selinux/assets_test.go
+++ b/pkg/assets/selinux/assets_test.go
@@ -17,6 +17,7 @@
 package selinux
 
 import (
+	"os"
 	"testing"
 
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
@@ -32,7 +33,7 @@ func TestGetPolicy(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:          "latest", // at time of writing. Keep me updated!
-			ver:           platform.Version("v4.16"),
+			ver:           platform.Version("v4.18"),
 			expectedError: false,
 		},
 		{
@@ -60,5 +61,17 @@ func TestGetPolicy(t *testing.T) {
 				t.Fatalf("GetPolicy(%v) unexpected result: expected error %v got %v", tc.ver, tc.expectedError, gotErr)
 			}
 		})
+	}
+}
+
+func TestPolicyDir(t *testing.T) {
+	numOfVersions := len(knownVersions())
+	dir, err := os.ReadDir(policyDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	numOfCils := len(dir)
+	if numOfVersions != numOfCils {
+		t.Fatalf("number of known version is different than number of cil files. knownVersions=%d,  cil files=%d", numOfVersions, numOfCils)
 	}
 }

--- a/pkg/assets/selinux/policy/ocp_v4.17.cil
+++ b/pkg/assets/selinux/policy/ocp_v4.17.cil
@@ -1,0 +1,24 @@
+(block rte
+	(type process)
+	(roletype system_r process)
+	(typeattributeset domain (process))
+	;
+	; Giving rte.process the same attributes as container_t
+	(typeattributeset container_domain (process))
+	(typeattributeset container_net_domain (process))
+	(typeattributeset svirt_sandbox_domain (process))
+	(typeattributeset sandbox_net_domain (process))
+	; MCS is leveraged by container_t and others, like us, to prevent cross-pod communication.
+	(typeattributeset mcs_constrained_type (process))
+	;
+	; Allow access to procfs (also needed by libraries)
+	(allow process proc_type (file (open read)))
+	;
+	; Allow to RTE pod access to /run/rte directory
+	(allow process container_var_run_t (dir (add_name write)))
+	(allow process container_var_run_t (file (create read write open)))
+	;
+	; Allow to RTE pod connect, read and write permissions to /var/lib/kubelet/pod-resource/kubelet.sock
+	(allow process container_var_lib_t (sock_file (open getattr read write ioctl lock append)))
+	(allow process kubelet_t (unix_stream_socket (connectto)))
+)

--- a/pkg/assets/selinux/policy/ocp_v4.18.cil
+++ b/pkg/assets/selinux/policy/ocp_v4.18.cil
@@ -1,0 +1,25 @@
+(block rte
+	(type process)
+	(roletype system_r process)
+	(typeattributeset domain (process))
+	;
+	; Giving rte.process the same attributes as container_t
+	(typeattributeset container_domain (process))
+	(typeattributeset container_net_domain (process))
+	(typeattributeset svirt_sandbox_domain (process))
+	(typeattributeset sandbox_net_domain (process))
+	; MCS is leveraged by container_t and others, like us, to prevent cross-pod communication.
+	(typeattributeset mcs_constrained_type (process))
+	;
+	; Allow access to procfs (also needed by libraries)
+	(allow process proc_type (file (open read)))
+	;
+	; Allow to RTE pod access to /run/rte directory
+	(allow process container_var_run_t (dir (add_name write)))
+	(allow process container_var_run_t (file (create read write open)))
+	;
+	; Allow to RTE pod connect, read and write permissions to /var/lib/kubelet/pod-resource/kubelet.sock
+	(allow process container_var_lib_t (sock_file (open getattr read write ioctl lock append)))
+	(allow process kubelet_var_lib_t (sock_file (open getattr read write ioctl lock append)))
+	(allow process kubelet_t (unix_stream_socket (connectto)))
+)


### PR DESCRIPTION
podresources API context has changed to kubelet_var_lib_t:
 https://github.com/containers/container-selinux/pull/329

Adjust the custom policy to allow access to this new file context.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>