### PR TITLE
[release-0.21][manual] selinux: add kubelet_var_lib_t permissions

### DIFF
--- a/pkg/assets/selinux/policy/ocp_v4.16.cil
+++ b/pkg/assets/selinux/policy/ocp_v4.16.cil
@@ -20,5 +20,6 @@
 	;
 	; Allow to RTE pod connect, read and write permissions to /var/lib/kubelet/pod-resource/kubelet.sock
 	(allow process container_var_lib_t (sock_file (open getattr read write ioctl lock append)))
+	(allow process kubelet_var_lib_t (sock_file (open getattr read write ioctl lock append)))
 	(allow process kubelet_t (unix_stream_socket (connectto)))
 )

--- a/pkg/assets/selinux/policy/ocp_v4.17.cil
+++ b/pkg/assets/selinux/policy/ocp_v4.17.cil
@@ -20,5 +20,6 @@
 	;
 	; Allow to RTE pod connect, read and write permissions to /var/lib/kubelet/pod-resource/kubelet.sock
 	(allow process container_var_lib_t (sock_file (open getattr read write ioctl lock append)))
+	(allow process kubelet_var_lib_t (sock_file (open getattr read write ioctl lock append)))
 	(allow process kubelet_t (unix_stream_socket (connectto)))
 )


### PR DESCRIPTION
In future rhel/rhcos release podresourceAPI socket file's context might change to `kubelet_var_lib_t`.

To deal with this issue in advance we'll change RTE custom policy to support this new context as well.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>
(cherry picked from commit 12718ed5c8ea8647588b28104c371a0096759663)