### PR TITLE
gh actions: bump versions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,7 +11,7 @@ defaults:
 
 jobs:
   e2e-positive:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - name: checkout sources
       uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
         _out/e2e.test -ginkgo.focus='\[PositiveFlow\]' -ginkgo.v
 
   e2e-negative:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - name: checkout sources
       uses: actions/checkout@v4
@@ -87,7 +87,7 @@ jobs:
         _out/e2e.test -ginkgo.focus='\[NegativeFlow\]' -ginkgo.v
 
   e2e-manifests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - name: checkout sources
       uses: actions/checkout@v4

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ defaults:
 
 jobs:
   release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - name: checkout sources
       uses: actions/checkout@v4
@@ -79,7 +79,7 @@ jobs:
 
     - name: archive kind logs
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: kind-logs
         path: /tmp/kind-logs


### PR DESCRIPTION
bump base images and actions versions
to fix up the warnings and be a bit more future proof.