### PR TITLE
manifests: selinux: openshift add v2 SCC

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -465,6 +465,24 @@ func SecurityContextConstraint(component string, withCustomSELinuxPolicy bool) (
 	return scc, nil
 }
 
+func SecurityContextConstraintV2(component string) (*securityv1.SecurityContextConstraints, error) {
+	if component != ComponentResourceTopologyExporter {
+		return nil, fmt.Errorf("component %q is not an %q component", component, ComponentResourceTopologyExporter)
+	}
+
+	obj, err := loadObject(filepath.Join("yaml", component, "securitycontextconstraintv2.yaml"))
+	if err != nil {
+		return nil, err
+	}
+
+	scc, ok := obj.(*securityv1.SecurityContextConstraints)
+	if !ok {
+		return nil, fmt.Errorf("unexpected type, got %t", obj)
+	}
+
+	return scc, nil
+}
+
 func validateComponent(component string) error {
 	if component == ComponentAPI || component == ComponentResourceTopologyExporter || component == ComponentNodeFeatureDiscovery || component == ComponentSchedulerPlugin {
 		return nil

--- a/pkg/manifests/rte/rte.go
+++ b/pkg/manifests/rte/rte.go
@@ -48,8 +48,9 @@ type Manifests struct {
 	DaemonSet          *appsv1.DaemonSet
 
 	// OpenShift related components
-	MachineConfig             *machineconfigv1.MachineConfig
-	SecurityContextConstraint *securityv1.SecurityContextConstraints
+	MachineConfig               *machineconfigv1.MachineConfig
+	SecurityContextConstraint   *securityv1.SecurityContextConstraints
+	SecurityContextConstraintV2 *securityv1.SecurityContextConstraints
 
 	// internal fields
 	plat platform.Platform
@@ -74,6 +75,7 @@ func (mf Manifests) Clone() Manifests {
 			ret.MachineConfig = mf.MachineConfig.DeepCopy()
 		}
 		ret.SecurityContextConstraint = mf.SecurityContextConstraint.DeepCopy()
+		ret.SecurityContextConstraintV2 = mf.SecurityContextConstraintV2.DeepCopy()
 	}
 
 	return ret
@@ -125,6 +127,7 @@ func (mf Manifests) Render(opts options.UpdaterDaemon) (Manifests, error) {
 		}
 		rteupdate.SecurityContext(ret.DaemonSet, selinuxType)
 		ocpupdate.SecurityContextConstraint(ret.SecurityContextConstraint, ret.ServiceAccount)
+		ocpupdate.SecurityContextConstraint(ret.SecurityContextConstraintV2, ret.ServiceAccount)
 	}
 
 	return ret, nil
@@ -193,6 +196,10 @@ func NewWithOptions(opts options.Render) (Manifests, error) {
 	}
 	if opts.Platform != platform.Kubernetes {
 		mf.SecurityContextConstraint, err = manifests.SecurityContextConstraint(manifests.ComponentResourceTopologyExporter, opts.CustomSELinuxPolicy)
+		if err != nil {
+			return mf, err
+		}
+		mf.SecurityContextConstraintV2, err = manifests.SecurityContextConstraintV2(manifests.ComponentResourceTopologyExporter)
 		if err != nil {
 			return mf, err
 		}

--- a/pkg/manifests/yaml/rte/securitycontextconstraintv2.yaml
+++ b/pkg/manifests/yaml/rte/securitycontextconstraintv2.yaml
@@ -1,0 +1,25 @@
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: resource-topology-exporter-v2
+allowHostDirVolumePlugin: true
+fsGroup:
+  type: RunAsAny
+readOnlyRootFilesystem: false
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  seLinuxOptions:
+    level: s0
+    type: container_device_plugin_t
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users: []
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- hostPath
+- projected
+- secret


### PR DESCRIPTION
add a new SecurityContextConstraints object, alongside the existing one, with all the recommended settings enabled and narrowed down privileges. Can be used with OpenShift >= 4.18.