### PR TITLE
 manifests: selinux: openshift add v2 SCC - fixes

### DIFF
--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -24,6 +24,17 @@ import (
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
 )
 
+type SCCVersion string
+
+const (
+	SCCV1 SCCVersion = "v1"
+	SCCV2 SCCVersion = "v2"
+)
+
+func IsValidSCCVersion(ver string) bool {
+	return ver == string(SCCV1) || ver == string(SCCV2)
+}
+
 type Options struct {
 	UserPlatform                platform.Platform
 	UserPlatformVersion         platform.Version
@@ -35,6 +46,7 @@ type Options struct {
 	UpdaterNotifEnable          bool
 	UpdaterCRIHooksEnable       bool
 	UpdaterCustomSELinuxPolicy  bool
+	UpdaterSCCVersion           SCCVersion
 	UpdaterSyncPeriod           time.Duration
 	UpdaterVerbose              int
 	SchedProfileName            string
@@ -78,6 +90,7 @@ type DaemonSet struct {
 	NotificationEnable bool
 	NodeSelector       *metav1.LabelSelector
 	UpdateInterval     time.Duration
+	SCCVersion         SCCVersion
 }
 
 type UpdaterDaemon struct {
@@ -112,6 +125,7 @@ func ForDaemonSet(commonOpts *Options) DaemonSet {
 		PFPEnable:          commonOpts.UpdaterPFPEnable,
 		NotificationEnable: commonOpts.UpdaterNotifEnable,
 		UpdateInterval:     commonOpts.UpdaterSyncPeriod,
+		SCCVersion:         commonOpts.UpdaterSCCVersion,
 		Verbose:            commonOpts.UpdaterVerbose,
 	}
 }


### PR DESCRIPTION
further test prove https://github.com/k8stopologyawareschedwg/deployer/pull/346 was incomplete.

We had a subtle bug which prevented the SCC V2 to be reported in the output of `ToObjects()`.
Also missing was the required wiring to let users select the SCC version from the command line tool.

Unfortunately OpenShift/HyperShift features need to be tested offline because this project lacks CI for these environments, and this missteps may happen.

A future PR will introduce (more) test coverage to reduce the chances of further missteps