### PR TITLE
SCC: Added annotation to daemonset pods template

### DIFF
--- a/pkg/manifests/rte/rte.go
+++ b/pkg/manifests/rte/rte.go
@@ -125,7 +125,13 @@ func (mf Manifests) Render(opts options.UpdaterDaemon) (Manifests, error) {
 		}
 		ocpupdate.SecurityContextConstraint(ret.SecurityContextConstraint, ret.ServiceAccount)
 		ocpupdate.SecurityContextConstraint(ret.SecurityContextConstraintV2, ret.ServiceAccount)
-		rteupdate.SecurityContext(ret.DaemonSet, selinuxTypeFromSCCVersion(opts.DaemonSet.SCCVersion, (mf.MachineConfig != nil)))
+		rteupdate.SecurityContextWithOpts(
+			ret.DaemonSet,
+			rteupdate.SecurityContextOptions{
+				SELinuxContextType:  selinuxTypeFromSCCVersion(opts.DaemonSet.SCCVersion, (mf.MachineConfig != nil)),
+				SecurityContextName: mf.SecurityContextConstraint.Name,
+			},
+		)
 	}
 
 	return ret, nil


### PR DESCRIPTION
Since OCP 4.18, all workloads of platform namespaces (openshift-*) explicitly pin the SCCs they need.

https://docs.openshift.com/container-platform/4.17/authentication/managing-security-context-constraints.html#security-context-constraints-requiring_configuring-internal-oauth

https://github.com/openshift/origin/blob/master/pkg/monitortests/authentication/requiredsccmonitortests/monitortest.go