### PR TITLE
rte: selinux: missing v2 SCC creation and deletion

### DIFF
--- a/pkg/objectwait/rte/rte.go
+++ b/pkg/objectwait/rte/rte.go
@@ -42,6 +42,12 @@ func Creatable(mf rtemf.Manifests, cli client.Client, log logr.Logger) []objectw
 		})
 	}
 
+	if mf.SecurityContextConstraintV2 != nil {
+		objs = append(objs, objectwait.WaitableObject{
+			Obj: mf.SecurityContextConstraintV2,
+		})
+	}
+
 	if mf.MachineConfig != nil {
 		// TODO: we should add functionality to wait for the MCP update
 		objs = append(objs, objectwait.WaitableObject{
@@ -90,6 +96,11 @@ func Deletable(mf rtemf.Manifests, cli client.Client, log logr.Logger) []objectw
 	if mf.SecurityContextConstraint != nil {
 		objs = append(objs, objectwait.WaitableObject{
 			Obj: mf.SecurityContextConstraint,
+		})
+	}
+	if mf.SecurityContextConstraintV2 != nil {
+		objs = append(objs, objectwait.WaitableObject{
+			Obj: mf.SecurityContextConstraintV2,
 		})
 	}
 	if mf.MachineConfig != nil {


### PR DESCRIPTION
This PR complements the work done in #348.
The sections added were missing, which subsequently prevented the SCC v2 from being deployed.

