### PR TITLE
[release-0.19] github actions: build releases only for majors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   push:
     # Sequence of patterns matched against refs/tags
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.0"
 
 defaults:
   run:


### PR DESCRIPTION
patch versions don't need binaries, and, unless
rare cases which can manage manually for the time being, don't change manifests.

From the last few years, patch versions are usually needed to fix/backport golang packages, so we can save space and CI credits and just consume tags.


(cherry picked from commit b1c82e1d00f7e359d2ef56567536586a725af857)