### PR TITLE
rte: specify priority class

### DIFF
--- a/pkg/manifests/yaml/rte/daemonset.yaml
+++ b/pkg/manifests/yaml/rte/daemonset.yaml
@@ -15,6 +15,7 @@ spec:
       - conditionType: "PodresourcesFetched"
       - conditionType: "NodeTopologyUpdated"
       serviceAccountName: rte
+      priorityClassName: system-node-critical
       containers:
       - name: resource-topology-exporter
         image: quay.io/k8stopologyawareschedwg/resource-topology-exporter:latest


### PR DESCRIPTION
Till today, the priority class of RTEs is 0 which is the default which is the lowest priority possible and is the first one in danger of being evicted. The first consumer of the RTE functionality is the topology-aware secondary scheduler which has `system-node-critical` priority class. RTE having a lower priority class risks the performance of the scheduler. and if RTE pods are evicted the scheduler becomes unreliable and completely blocked.

Increase the priority class of RTEs to `system-node-critical` to lessen the possibility of the daemonset pods getting evicted. This is especially needed for compact cluster use cases where eviction is more frequent due to prioritizing system-critical workloads.


(cherry picked from commit dbbdf395ca3709602d64a04f55309126ba4866e6)